### PR TITLE
feat(core): Use a container to compile protos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to kleat
+
+## Protocol buffers
+
+### Overview
+
+Kleat's data model is expressed as [protocol buffers](https://developers.google.com/protocol-buffers)
+in the [/api/proto](api/proto) directory. For example, the [hal config proto](/api/proto/halconfig.proto)
+represents the source of truth for what fields are valid in a hal config.
+
+These protocol buffers are then transformed to generate:
+
+- A [go library](/api/client) used by kleat to interact with its data model
+- [Documentation](/docs/docs.md) of the data model
+
+### Regenerating dependent code
+
+In order to keep the go library and documentation in sync with the protocol buffers, any commit that
+changes a protocol buffer must regenerate any dependent code by running the following and committing
+the result:
+
+```bash
+make proto
+```
+
+This command requires that `docker` be installed, but has no other dependencies. The fist time it
+is run, it may take a minute or two as it builds the container image it will use to compile the
+protocol buffers; subsequent runs will be significantly faster.
+
+By compiling protocol buffers in a container with explicitly-specified dependencies, we avoid
+having this compilation depend on the versions of tools on a particular contributor's machine
+(and in fact don't require contributors to have these tools at all, in exchange for requiring that
+they have `docker`).
+
+### Upgrading protocol buffer libraries
+
+The versions of all tools used to compile the protocol buffers are specified in the
+[Dockerfile](/build/protoc/Dockerfile). To update the version of one of these dependencies,
+make the appropriate change to the Dockerfile, run `make proto`, and commit any changes.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 protobuilder:
 	docker build -q -t kleat-protobuilder:latest build/protoc/
 
-proto_command = docker run --rm -v $(abspath api/proto/):/proto -v $(abspath api/client):/output/go -v$(abspath docs):/output/doc kleat-protobuilder:latest
+proto_command = docker run --rm -v $(abspath api/proto/):/proto -v $(abspath api/client):/output/go -v $(abspath docs):/output/doc kleat-protobuilder:latest
 
 proto: protobuilder
 	$(proto_command) update

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+protobuilder:
+	docker build -q -t kleat-protobuilder:latest build/protoc/
+
+proto_command = docker run --rm -v $(abspath api/proto/):/proto -v $(abspath api/client):/output/go -v$(abspath docs):/output/doc kleat-protobuilder:latest
+
+proto: protobuilder
+	$(proto_command) update
+
+checkproto: protobuilder
+	$(proto_command) check

--- a/build/protoc/Dockerfile
+++ b/build/protoc/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.14.1-alpine as builder
+RUN apk add --no-cache git
+
+FROM builder as protoc-gen-go
+ARG PROTOC_GEN_GO_TAG=v1.3.3
+RUN go get -d github.com/golang/protobuf/protoc-gen-go \
+ && git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout $PROTOC_GEN_GO_TAG \
+ && go install github.com/golang/protobuf/protoc-gen-go
+
+FROM builder as protoc-gen-doc
+ARG PROTOC_GEN_DOC_TAG=v1.3.1
+RUN go get -d github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc \
+ && git -C "$(go env GOPATH)"/src/github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc checkout $PROTOC_GEN_DOC_TAG \
+ && go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+
+FROM alpine:3.11.5
+RUN apk add protoc
+COPY --from=protoc-gen-go /go/bin/protoc-gen-go /bin/
+COPY --from=protoc-gen-doc /go/bin/protoc-gen-doc /bin/
+RUN mkdir -p /output /staging/go /staging/doc
+COPY genproto.sh .
+ENTRYPOINT ["./genproto.sh"]

--- a/build/protoc/genproto.sh
+++ b/build/protoc/genproto.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+gen_proto() {
+  output_dir=$1
+  find /proto -name *.proto | sort | xargs protoc --proto_path=/proto --go_out=paths=source_relative:$1/go --doc_out=$1/doc --doc_opt=markdown,docs.md
+}
+
+update_proto() {
+  rm -rf /output/go/* /output/doc/*
+  gen_proto /output
+}
+
+check_proto() {
+  gen_proto /staging
+  if ! diff -r /staging /output; then
+    echo "Protocol buffer compilation out of date. Please run 'make proto' and commit the changes."
+    echo "To help with debugging, the difference between the committed and generated code is printed above."
+    exit 1
+  fi
+}
+
+command=$1
+case $command in
+  update)
+    update_proto
+    ;;
+  check)
+    check_proto
+    ;;
+  *)
+    echo "Unrecognized command: $command"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Compiling the protos requires a number of tools to be installed on the local machine (protoc, protoc-gen-go, protoc-gen-doc). While it's not too difficult to set this up once, differences in version of these tools between different contributors can lead to large diffs in generated output, and also makes is difficult to write tooling that ensures that the generated output is in sync.

This commit creates a Dockerfile containing all the required tools at pinned versions. Now all that is needed to compile the protos reproducibly is to have docker installed.

It also adds a Makefile to make it easy to regenerate the protos. Running 'make proto' will update all generated code based on the current status of the proto files. Running 'make checkproto' will check if the generated code and protos are currently in sync, but will not update any of the generated code. (The idea is that 'make checkproto' can be run as part of pre-merge CI to ensure that these always stay in sync.)