### PR TITLE
refactor(packages): move non-internal packages to /pkg

### DIFF
--- a/internal/validate_paths/validate_paths.go
+++ b/internal/validate_paths/validate_paths.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package validate
+package validate_paths
 
 import (
 	"errors"

--- a/internal/write/write_configs.go
+++ b/internal/write/write_configs.go
@@ -17,31 +17,32 @@ package write
 
 import (
 	"github.com/ghodss/yaml"
-	"github.com/spinnaker/kleat/internal/parse"
-	"github.com/spinnaker/kleat/internal/validate"
+	"github.com/spinnaker/kleat/internal/validate_paths"
+	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/pkg/validate_hal"
 	"io"
 	"os"
 	"path/filepath"
 )
 
 func WriteConfigs(hal string, d string) error {
-	if err := validate.EnsureFile(hal); err != nil {
+	if err := validate_paths.EnsureFile(hal); err != nil {
 		return err
 	}
-	if err := validate.EnsureDirectory(d); err != nil {
+	if err := validate_paths.EnsureDirectory(d); err != nil {
 		return err
 	}
 
-	h, err := parse.ParseHalConfig(hal)
+	h, err := parse_hal.ParseHalConfig(hal)
 	if err != nil {
 		return err
 	}
 
-	if err := validate.ValidateHalConfig(h); err != nil {
+	if err := validate_hal.ValidateHalConfig(h); err != nil {
 		return err
 	}
 
-	c, err := parse.HalToClouddriver(*h)
+	c, err := parse_hal.HalToClouddriver(*h)
 	if err != nil {
 		return err
 	}

--- a/pkg/parse_hal/parse_hal.go
+++ b/pkg/parse_hal/parse_hal.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse
+package parse_hal
 
 import (
 	"github.com/ghodss/yaml"

--- a/pkg/validate_hal/validate_hal.go
+++ b/pkg/validate_hal/validate_hal.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package validate
+package validate_hal
 
 import (
 	"errors"

--- a/test/hal_to_clouddriver_test.go
+++ b/test/hal_to_clouddriver_test.go
@@ -19,18 +19,18 @@ import (
 	"bytes"
 	"github.com/ghodss/yaml"
 	"github.com/spinnaker/kleat/api/client"
-	"github.com/spinnaker/kleat/internal/parse"
+	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"io/ioutil"
 	"testing"
 )
 
 func TestHalToClouddriver(t *testing.T) {
-	h, err := parse.ParseHalConfig("./data/halconfig.yml")
+	h, err := parse_hal.ParseHalConfig("./data/halconfig.yml")
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	gotC, err := parse.HalToClouddriver(*h)
+	gotC, err := parse_hal.HalToClouddriver(*h)
 	if err != nil {
 		t.Errorf(err.Error())
 	}


### PR DESCRIPTION
In addition to the autogenerated Go client, the operator eventually plans to consume Kleat's 
- methods for transforming a halconfig into each service config
- method for validating a halconfig

Let's move those packages from /internal to a new [/pkg](https://github.com/golang-standards/project-layout/tree/master/pkg) directory, which is the standard for library code.