### PR TITLE
feat(docs): document poor performance of sortTagsByDate flag

### DIFF
--- a/api/client/docker_registry_provider.pb.go
+++ b/api/client/docker_registry_provider.pb.go
@@ -147,7 +147,8 @@ type DockerRegistryAccount struct {
 	// `registries _catalog` endpoint.
 	Repositories []string `protobuf:"bytes,15,rep,name=repositories,proto3" json:"repositories,omitempty"`
 	// If `true`, Spinnaker will sort tags by creation date. Defaults to
-	// `false`.
+	// `false`. Not recommended for use with large registries; sorting
+	// performance scales poorly due to limitations of the Docker V2 API.
 	SortTagsByDate bool `protobuf:"varint,16,opt,name=sortTagsByDate,proto3" json:"sortTagsByDate,omitempty"`
 	// If `true`, Spinnaker will track digest changes. This is not recommended
 	// because it greatly increases queries to the registry, and most

--- a/api/proto/docker_registry_provider.proto
+++ b/api/proto/docker_registry_provider.proto
@@ -83,7 +83,8 @@ message DockerRegistryAccount {
     repeated string repositories = 15;
 
     // If `true`, Spinnaker will sort tags by creation date. Defaults to
-    // `false`.
+    // `false`. Not recommended for use with large registries; sorting
+    // performance scales poorly due to limitations of the Docker V2 API.
     bool sortTagsByDate = 16;
 
     // If `true`, Spinnaker will track digest changes. This is not recommended

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1023,7 +1023,7 @@ A credential able to authenticate against a set of Docker repositories.
 | permissions | [Permissions](#proto.Permissions) |  | Fiat permissions configuration. |
 | requiredGroupMemberships | [string](#string) | repeated | (Deprecated) List of required Fiat permission groups. Configure `permissions` instead. |
 | repositories | [string](#string) | repeated | An optional list of repositories from which to cache images. If not provided, Spinnaker will attempt to read accessible repositories from the `registries _catalog` endpoint. |
-| sortTagsByDate | [bool](#bool) |  | If `true`, Spinnaker will sort tags by creation date. Defaults to `false`. |
+| sortTagsByDate | [bool](#bool) |  | If `true`, Spinnaker will sort tags by creation date. Defaults to `false`. Not recommended for use with large registries; sorting performance scales poorly due to limitations of the Docker V2 API. |
 | trackDigests | [bool](#bool) |  | If `true`, Spinnaker will track digest changes. This is not recommended because it greatly increases queries to the registry, and most registries are flaky. Defaults to `false`. |
 | username | [string](#string) |  | The username associated with this Docker registry. |
 


### PR DESCRIPTION
As reported in https://github.com/spinnaker/spinnaker/issues/5538, the `sortTagsByDate` flag has prohibitive performance implications for registries with tens or hundreds of thousands of tags. However, we learned from conversations in Slack and at the Kubernetes SIG that users with smaller registries still find this flag valuable. Let's at least add a warning to the documentation, and in the future we can revisit either removing the flag or improving the performance of its implementation if the Docker V2 API ever supports fetching tags chronologically (or even batching requests for individual tags to get their creation date).

Corresponding Halyard PR: https://github.com/spinnaker/halyard/pull/1639