### PR TITLE
fix(core): Fix some NPEs in validation and config generation

### DIFF
--- a/internal/write/write_configs.go
+++ b/internal/write/write_configs.go
@@ -43,18 +43,18 @@ func WriteConfigs(hal string, d string) error {
 		return err
 	}
 
-	if err := writeClouddriver(*h, d); err != nil {
+	if err := writeClouddriver(h, d); err != nil {
 		return err
 	}
 
-	if err := writeEcho(*h, d); err != nil {
+	if err := writeEcho(h, d); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func writeClouddriver(h client.HalConfig, d string) error {
+func writeClouddriver(h *client.HalConfig, d string) error {
 	c, err := parse_hal.HalToClouddriver(h)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func writeClouddriver(h client.HalConfig, d string) error {
 	return nil
 }
 
-func writeEcho(h client.HalConfig, d string) error {
+func writeEcho(h *client.HalConfig, d string) error {
 	c, err := parse_hal.HalToEcho(h)
 	if err != nil {
 		return err

--- a/pkg/parse_hal/parse_hal.go
+++ b/pkg/parse_hal/parse_hal.go
@@ -45,29 +45,29 @@ func HalToFront50(h client.HalConfig) (client.Front50Config, error) {
 
 func HalToClouddriver(h client.HalConfig) (client.ClouddriverConfig, error) {
 	c := client.ClouddriverConfig{
-		Kubernetes:     h.Providers.Kubernetes,
-		Google:         h.Providers.Google,
-		Appengine:      h.Providers.Appengine,
-		Aws:            h.Providers.Aws,
-		Azure:          h.Providers.Azure,
-		Cloudfoundry:   h.Providers.Cloudfoundry,
-		Dcos:           h.Providers.Dcos,
-		DockerRegistry: h.Providers.DockerRegistry,
-		Ecs:            h.Providers.Ecs,
-		Huaweicloud:    h.Providers.Huaweicloud,
-		Oracle:         h.Providers.Oracle,
-		Artifacts:      h.Artifacts,
+		Kubernetes:     h.GetProviders().GetKubernetes(),
+		Google:         h.GetProviders().GetGoogle(),
+		Appengine:      h.GetProviders().GetAppengine(),
+		Aws:            h.GetProviders().GetAws(),
+		Azure:          h.GetProviders().GetAzure(),
+		Cloudfoundry:   h.GetProviders().GetCloudfoundry(),
+		Dcos:           h.GetProviders().GetDcos(),
+		DockerRegistry: h.GetProviders().GetDockerRegistry(),
+		Ecs:            h.GetProviders().GetEcs(),
+		Huaweicloud:    h.GetProviders().GetHuaweicloud(),
+		Oracle:         h.GetProviders().GetOracle(),
+		Artifacts:      h.GetArtifacts(),
 	}
 	return c, nil
 }
 
 func HalToEcho(h client.HalConfig) (client.EchoConfig, error) {
 	c := client.EchoConfig{
-		Slack:        h.Notifications.Slack,
-		Twilio:       h.Notifications.Twilio,
-		GithubStatus: h.Notifications.GithubStatus,
-		Artifacts:    h.Artifacts,
-		Pubsub:       h.Pubsub,
+		Slack:        h.GetNotifications().GetSlack(),
+		Twilio:       h.GetNotifications().GetTwilio(),
+		GithubStatus: h.GetNotifications().GetGithubStatus(),
+		Artifacts:    h.GetArtifacts(),
+		Pubsub:       h.GetPubsub(),
 	}
 	return c, nil
 }

--- a/pkg/parse_hal/parse_hal.go
+++ b/pkg/parse_hal/parse_hal.go
@@ -33,8 +33,8 @@ func ParseHalConfig(fn string) (*client.HalConfig, error) {
 	return &h, nil
 }
 
-func HalToFront50(h client.HalConfig) (client.Front50Config, error) {
-	f := client.Front50Config{
+func HalToFront50(h *client.HalConfig) (*client.Front50Config, error) {
+	f := &client.Front50Config{
 		Spinnaker: &client.Front50Config_Spinnaker{
 			PersistentStoreType: h.PersistentStorage.PersistentStoreType,
 			Gcs:                 h.PersistentStorage.Gcs,
@@ -43,8 +43,8 @@ func HalToFront50(h client.HalConfig) (client.Front50Config, error) {
 	return f, nil
 }
 
-func HalToClouddriver(h client.HalConfig) (client.ClouddriverConfig, error) {
-	c := client.ClouddriverConfig{
+func HalToClouddriver(h *client.HalConfig) (*client.ClouddriverConfig, error) {
+	c := &client.ClouddriverConfig{
 		Kubernetes:     h.GetProviders().GetKubernetes(),
 		Google:         h.GetProviders().GetGoogle(),
 		Appengine:      h.GetProviders().GetAppengine(),
@@ -61,8 +61,8 @@ func HalToClouddriver(h client.HalConfig) (client.ClouddriverConfig, error) {
 	return c, nil
 }
 
-func HalToEcho(h client.HalConfig) (client.EchoConfig, error) {
-	c := client.EchoConfig{
+func HalToEcho(h *client.HalConfig) (*client.EchoConfig, error) {
+	c := &client.EchoConfig{
 		Slack:        h.GetNotifications().GetSlack(),
 		Twilio:       h.GetNotifications().GetTwilio(),
 		GithubStatus: h.GetNotifications().GetGithubStatus(),

--- a/pkg/parse_hal/parse_hal_test.go
+++ b/pkg/parse_hal/parse_hal_test.go
@@ -23,33 +23,33 @@ import (
 )
 
 func TestEmptyHalConfigToClouddriver(t *testing.T) {
-	h := client.HalConfig{}
+	h := &client.HalConfig{}
 	gotC, err := HalToClouddriver(h)
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{}
+	wantC := &client.ClouddriverConfig{}
 	if !reflect.DeepEqual(gotC, wantC) {
 		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
 	}
 }
 
 func TestEmptyProvidersToClouddriver(t *testing.T) {
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Providers: &client.HalConfig_Providers{},
 	}
 	gotC, err := HalToClouddriver(h)
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{}
+	wantC := &client.ClouddriverConfig{}
 	if !reflect.DeepEqual(gotC, wantC) {
 		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
 	}
 }
 
 func TestEmptyKubernetesProviderToClouddriverConfig(t *testing.T) {
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Providers: &client.HalConfig_Providers{
 			Kubernetes: &client.KubernetesProvider{},
 		},
@@ -58,7 +58,7 @@ func TestEmptyKubernetesProviderToClouddriverConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{
+	wantC := &client.ClouddriverConfig{
 		Kubernetes: &client.KubernetesProvider{},
 	}
 	if !reflect.DeepEqual(gotC, wantC) {
@@ -78,7 +78,7 @@ func TestKubernetesAccountToClouddriver(t *testing.T) {
 		},
 		PrimaryAccount: "my-account",
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Providers: &client.HalConfig_Providers{
 			Kubernetes: k,
 		},
@@ -87,7 +87,7 @@ func TestKubernetesAccountToClouddriver(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{
+	wantC := &client.ClouddriverConfig{
 		Kubernetes: k,
 	}
 	if !reflect.DeepEqual(gotC, wantC) {
@@ -96,14 +96,14 @@ func TestKubernetesAccountToClouddriver(t *testing.T) {
 }
 
 func TestEmptyArtifactsToHalConfig(t *testing.T) {
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Artifacts: &client.ArtifactProviders{},
 	}
 	gotC, err := HalToClouddriver(h)
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{
+	wantC := &client.ClouddriverConfig{
 		Artifacts: &client.ArtifactProviders{},
 	}
 	if !reflect.DeepEqual(gotC, wantC) {
@@ -115,14 +115,14 @@ func TestEmptyGcsArtifactConfigToHalConfig(t *testing.T) {
 	a := &client.ArtifactProviders{
 		Gcs: &client.GcsArtifactProvider{},
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Artifacts: a,
 	}
 	gotC, err := HalToClouddriver(h)
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{
+	wantC := &client.ClouddriverConfig{
 		Artifacts: a,
 	}
 	if !reflect.DeepEqual(gotC, wantC) {
@@ -142,14 +142,14 @@ func TestGcsArtifactAccountToHalConfig(t *testing.T) {
 			},
 		},
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Artifacts: a,
 	}
 	gotC, err := HalToClouddriver(h)
 	if err != nil {
 		t.Errorf("Error writing clouddriver config %s", err)
 	}
-	wantC := client.ClouddriverConfig{
+	wantC := &client.ClouddriverConfig{
 		Artifacts: a,
 	}
 	if !reflect.DeepEqual(gotC, wantC) {
@@ -158,26 +158,26 @@ func TestGcsArtifactAccountToHalConfig(t *testing.T) {
 }
 
 func TestEmptyHalConfigToEcho(t *testing.T) {
-	h := client.HalConfig{}
+	h := &client.HalConfig{}
 	gotE, err := HalToEcho(h)
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{}
+	wantE := &client.EchoConfig{}
 	if !reflect.DeepEqual(gotE, wantE) {
 		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
 	}
 }
 
 func TestEmptyNotificationsToEchoConfig(t *testing.T) {
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Notifications: &client.HalConfig_Notifications{},
 	}
 	gotE, err := HalToEcho(h)
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{}
+	wantE := &client.EchoConfig{}
 	if !reflect.DeepEqual(gotE, wantE) {
 		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
 	}
@@ -190,7 +190,7 @@ func TestSlackNotificationToEchoConfig(t *testing.T) {
 		Token:   "my-token",
 		BaseUrl: "https://slack.test/",
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Notifications: &client.HalConfig_Notifications{
 			Slack: slack,
 		},
@@ -199,7 +199,7 @@ func TestSlackNotificationToEchoConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{
+	wantE := &client.EchoConfig{
 		Slack: slack,
 	}
 	if !reflect.DeepEqual(gotE, wantE) {
@@ -208,14 +208,14 @@ func TestSlackNotificationToEchoConfig(t *testing.T) {
 }
 
 func TestEmptyPubsubsToEchoConfig(t *testing.T) {
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Pubsub: &client.PubsubProviders{},
 	}
 	gotE, err := HalToEcho(h)
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{
+	wantE := &client.EchoConfig{
 		Pubsub: &client.PubsubProviders{},
 	}
 	if !reflect.DeepEqual(gotE, wantE) {
@@ -227,14 +227,14 @@ func TestEmptyGooglePubsubToEchoConfig(t *testing.T) {
 	pubsub := &client.PubsubProviders{
 		Google: &client.GooglePubsub{},
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Pubsub: pubsub,
 	}
 	gotE, err := HalToEcho(h)
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{
+	wantE := &client.EchoConfig{
 		Pubsub: pubsub,
 	}
 	if !reflect.DeepEqual(gotE, wantE) {
@@ -263,14 +263,14 @@ func TestGooglePubsubToEchoConfig(t *testing.T) {
 			},
 		},
 	}
-	h := client.HalConfig{
+	h := &client.HalConfig{
 		Pubsub: pubsub,
 	}
 	gotE, err := HalToEcho(h)
 	if err != nil {
 		t.Errorf("Error writing echo config %s", err)
 	}
-	wantE := client.EchoConfig{
+	wantE := &client.EchoConfig{
 		Pubsub: pubsub,
 	}
 	if !reflect.DeepEqual(gotE, wantE) {

--- a/pkg/parse_hal/parse_hal_test.go
+++ b/pkg/parse_hal/parse_hal_test.go
@@ -1,0 +1,279 @@
+/*
+ * Copyright The Spinnaker Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parse_hal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spinnaker/kleat/api/client"
+)
+
+func TestEmptyHalConfigToClouddriver(t *testing.T) {
+	h := client.HalConfig{}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
+	}
+}
+
+func TestEmptyProvidersToClouddriver(t *testing.T) {
+	h := client.HalConfig{
+		Providers: &client.HalConfig_Providers{},
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
+	}
+}
+
+func TestEmptyKubernetesProviderToClouddriverConfig(t *testing.T) {
+	h := client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{},
+		},
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{
+		Kubernetes: &client.KubernetesProvider{},
+	}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected empty Kubernetes config in hal config to pass through to clouddriver config, got %+v", gotC)
+	}
+}
+
+func TestKubernetesAccountToClouddriver(t *testing.T) {
+	k := &client.KubernetesProvider{
+		Enabled: true,
+		Accounts: []*client.KubernetesAccount{
+			{
+				Name:           "my-account",
+				Kinds:          []string{"deployment"},
+				OmitNamespaces: []string{"kube-system"},
+			},
+		},
+		PrimaryAccount: "my-account",
+	}
+	h := client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: k,
+		},
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{
+		Kubernetes: k,
+	}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected kubernetes account to be in clouddriver config, got %+v", gotC)
+	}
+}
+
+func TestEmptyArtifactsToHalConfig(t *testing.T) {
+	h := client.HalConfig{
+		Artifacts: &client.ArtifactProviders{},
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{
+		Artifacts: &client.ArtifactProviders{},
+	}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected empty artifact providers to be passed to clouddriver config, got %+v", gotC)
+	}
+}
+
+func TestEmptyGcsArtifactConfigToHalConfig(t *testing.T) {
+	a := &client.ArtifactProviders{
+		Gcs: &client.GcsArtifactProvider{},
+	}
+	h := client.HalConfig{
+		Artifacts: a,
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{
+		Artifacts: a,
+	}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected empty GCS artifact config to be passed to clouddriver config, got %+v", gotC)
+	}
+}
+
+func TestGcsArtifactAccountToHalConfig(t *testing.T) {
+	a := &client.ArtifactProviders{
+		Gcs: &client.GcsArtifactProvider{
+			Enabled: true,
+			Accounts: []*client.GcsArtifactAccount{
+				{
+					Name:     "my-account",
+					JsonPath: "/var/secrets/my-key.json",
+				},
+			},
+		},
+	}
+	h := client.HalConfig{
+		Artifacts: a,
+	}
+	gotC, err := HalToClouddriver(h)
+	if err != nil {
+		t.Errorf("Error writing clouddriver config %s", err)
+	}
+	wantC := client.ClouddriverConfig{
+		Artifacts: a,
+	}
+	if !reflect.DeepEqual(gotC, wantC) {
+		t.Errorf("Expected GCS artifact config to be passed to clouddriver config, got %+v", gotC)
+	}
+}
+
+func TestEmptyHalConfigToEcho(t *testing.T) {
+	h := client.HalConfig{}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
+	}
+}
+
+func TestEmptyNotificationsToEchoConfig(t *testing.T) {
+	h := client.HalConfig{
+		Notifications: &client.HalConfig_Notifications{},
+	}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
+	}
+}
+
+func TestSlackNotificationToEchoConfig(t *testing.T) {
+	slack := &client.SlackNotification{
+		Enabled: true,
+		BotName: "my-bot",
+		Token:   "my-token",
+		BaseUrl: "https://slack.test/",
+	}
+	h := client.HalConfig{
+		Notifications: &client.HalConfig_Notifications{
+			Slack: slack,
+		},
+	}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{
+		Slack: slack,
+	}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected slack notifications to be passed through to echo config, got %v", gotE)
+	}
+}
+
+func TestEmptyPubsubsToEchoConfig(t *testing.T) {
+	h := client.HalConfig{
+		Pubsub: &client.PubsubProviders{},
+	}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{
+		Pubsub: &client.PubsubProviders{},
+	}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected empty pubsubs to be passed through to echo config, got %v", gotE)
+	}
+}
+
+func TestEmptyGooglePubsubToEchoConfig(t *testing.T) {
+	pubsub := &client.PubsubProviders{
+		Google: &client.GooglePubsub{},
+	}
+	h := client.HalConfig{
+		Pubsub: pubsub,
+	}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{
+		Pubsub: pubsub,
+	}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected empty Google pubsub config to be passed through to echo config, got %v", gotE)
+	}
+}
+
+func TestGooglePubsubToEchoConfig(t *testing.T) {
+	pubsub := &client.PubsubProviders{
+		Google: &client.GooglePubsub{
+			Subscriptions: []*client.GooglePubsubSubscriber{
+				{
+					Name:             "my-account",
+					Project:          "my-project",
+					SubscriptionName: "my-subscription",
+					JsonPath:         "/var/secrets/my-account.json",
+					MessageFormat:    "GCS",
+				},
+			},
+			Publishers: []*client.GooglePubsubPublisher{
+				{
+					Name:      "my-account",
+					Project:   "my-project",
+					TopicName: "my-topic",
+				},
+			},
+		},
+	}
+	h := client.HalConfig{
+		Pubsub: pubsub,
+	}
+	gotE, err := HalToEcho(h)
+	if err != nil {
+		t.Errorf("Error writing echo config %s", err)
+	}
+	wantE := client.EchoConfig{
+		Pubsub: pubsub,
+	}
+	if !reflect.DeepEqual(gotE, wantE) {
+		t.Errorf("Expected Google pubsub config to be passed through to echo config, got %v", gotE)
+	}
+}

--- a/pkg/validate_hal/validate_hal.go
+++ b/pkg/validate_hal/validate_hal.go
@@ -55,8 +55,8 @@ func getValidationMessages(h *client.HalConfig, fa []HalConfigValidator) []strin
 
 func validateKindsAndOmitKinds(h *client.HalConfig) []ValidationFailure {
 	var messages []ValidationFailure
-	for _, a := range h.Providers.Kubernetes.Accounts {
-		if !(len(a.Kinds) == 0) && !(len(a.OmitKinds) == 0) {
+	for _, a := range h.GetProviders().GetKubernetes().GetAccounts() {
+		if !(len(a.GetKinds()) == 0) && !(len(a.GetOmitKinds()) == 0) {
 			messages = append(messages, fatalResult("Cannot specify both kinds and omitKinds."))
 		}
 	}

--- a/pkg/validate_hal/validate_hal_test.go
+++ b/pkg/validate_hal/validate_hal_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright The Spinnaker Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package validate_hal
+
+import (
+	"testing"
+
+	"github.com/spinnaker/kleat/api/client"
+)
+
+func TestEmptyHalConfig(t *testing.T) {
+	h := &client.HalConfig{}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestEmptyProviders(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{},
+	}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestEmptyKubernetes(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{},
+		},
+	}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestNoKubernetesAccounts(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{
+				Enabled:  false,
+				Accounts: []*client.KubernetesAccount{},
+			},
+		},
+	}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestKuberntesAccountWithNoOmitKinds(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{
+				Accounts: []*client.KubernetesAccount{
+					{
+						Name:  "my-account",
+						Kinds: []string{"deployment"},
+					},
+				},
+			},
+		},
+	}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestKuberntesAccountWithEmptyOmitKinds(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{
+				Accounts: []*client.KubernetesAccount{
+					{
+						Name:      "my-account",
+						Kinds:     []string{"deployment"},
+						OmitKinds: []string{},
+					},
+				},
+			},
+		},
+	}
+	err := ValidateHalConfig(h)
+	if err != nil {
+		t.Errorf("Expected no validation failures, got %s", err)
+	}
+}
+
+func TestInvalidKubernetesAccount(t *testing.T) {
+	h := &client.HalConfig{
+		Providers: &client.HalConfig_Providers{
+			Kubernetes: &client.KubernetesProvider{
+				Accounts: []*client.KubernetesAccount{
+					{
+						Name:      "my-account",
+						Kinds:     []string{"deployment"},
+						OmitKinds: []string{"replicaSet"},
+					},
+				},
+			},
+		},
+	}
+	err := ValidateHalConfig(h)
+	if err == nil {
+		t.Error("Expected a validation failure, got none")
+	}
+}

--- a/test/hal_to_clouddriver_test.go
+++ b/test/hal_to_clouddriver_test.go
@@ -30,7 +30,7 @@ func TestHalToClouddriver(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	gotC, err := parse_hal.HalToClouddriver(*h)
+	gotC, err := parse_hal.HalToClouddriver(h)
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/test/hal_to_echo_test.go
+++ b/test/hal_to_echo_test.go
@@ -30,7 +30,7 @@ func TestHalToEcho(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	gotE, err := parse_hal.HalToEcho(*h)
+	gotE, err := parse_hal.HalToEcho(h)
 	if err != nil {
 		t.Errorf(err.Error())
 	}


### PR DESCRIPTION
* fix(core): Fix some NPEs in validation and config generation 

  In a few places in the config validation and translation we were dereferencing a potentially nil pointer. This happens when we we need to reach more than a level deep in the HalConfig and that top-level field is nil.

  A while back we discussed how to handle this, and considered seeing if we could deserialize as values instead of pointers so we could always rely on the zero value. But if I recall we decided against that because:
  (1) It is actually useful to have the nil value because it indicates something was not present in the config and should not be serialized to the service config
  (2) This problem will only happen in cases where we're reaching into the hal config, so the amount of places we need to do this nil check should be reasonable.

  Looking at the generated protos, it looks like there are actually nil-safe accessor generated. If you call x.GetY() it will first check if x is nil, and if so return nil; if not it will return x.y. This took a minute for me to wrap my Java brain around, because the (bad) analogy is basically an instance method on an object checking whether the object is nil. But somehow this works for receivers (I guess because type inference means we know the type of the receiver so which function to call, and we just get the receiver as a possibly-nil object). But this is really nice because it lets you write nil-safe chains as x.GetY().GetZ() that return nil at the end if anything was nil but never throw a nil-pointer panic.

  Also add some test to the validation and parsing modules to validate correct behavior in various edge cases (empty hal config, hal config with providers field but no providers, etc.)

* refactor(core): Standardize on using pointers 

  For a while we weren't sure whether to pass by value or by reference. Given that we're passing around structs whose nested fields are all themselves passed around by reference, it seems logical to do the same at the top level (as it's confusing that the top-level thing is sometimes passed around by value).

  This also resolves a bunch of 'go vet' warnings because the generated structs contain a mutex somewhere, which really should not be copied, and generates a warning when we pass these around by value. If I didn't think that it probably makes sense to pass by value anyway I'd probably spend more time seeing if that warning should be suppressed, but given that I think it makes sense anyway to pass by reference, let's do that.
