### PR TITLE
refactor(tests): convert parse_hal_test to table-based

### DIFF
--- a/pkg/parse_hal/parse_hal_test.go
+++ b/pkg/parse_hal/parse_hal_test.go
@@ -28,314 +28,319 @@ import (
 	"github.com/spinnaker/kleat/api/client/pubsub"
 )
 
-func TestEmptyHalConfigToClouddriver(t *testing.T) {
-	h := &config.Hal{}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
-	}
-}
-
-func TestEmptyProvidersToClouddriver(t *testing.T) {
-	h := &config.Hal{
-		Providers: &config.Hal_Providers{},
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected empty hal config to generate empty clouddriver config, got %v", gotC)
-	}
-}
-
-func TestEmptyKubernetesProviderToClouddriverConfig(t *testing.T) {
-	h := &config.Hal{
-		Providers: &config.Hal_Providers{
+var halToClouddriverTests = []struct {
+	n     string
+	h     *config.Hal
+	wantC *config.Clouddriver
+}{
+	{
+		"Empty hal config",
+		&config.Hal{},
+		&config.Clouddriver{},
+	},
+	{
+		"Empty providers",
+		&config.Hal{
+			Providers: &config.Hal_Providers{},
+		},
+		&config.Clouddriver{},
+	},
+	{
+		"Empty Kubernetes provider",
+		&config.Hal{
+			Providers: &config.Hal_Providers{
+				Kubernetes: &cloudprovider.Kubernetes{},
+			},
+		},
+		&config.Clouddriver{
 			Kubernetes: &cloudprovider.Kubernetes{},
 		},
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{
-		Kubernetes: &cloudprovider.Kubernetes{},
-	}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected empty Kubernetes config in hal config to pass through to clouddriver config, got %+v", gotC)
-	}
-}
-
-func TestKubernetesAccountToClouddriver(t *testing.T) {
-	k := &cloudprovider.Kubernetes{
-		Enabled: true,
-		Accounts: []*cloudprovider.KubernetesAccount{
-			{
-				Name:           "my-account",
-				Kinds:          []string{"deployment"},
-				OmitNamespaces: []string{"kube-system"},
-			},
-		},
-		PrimaryAccount: "my-account",
-	}
-	h := &config.Hal{
-		Providers: &config.Hal_Providers{
-			Kubernetes: k,
-		},
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{
-		Kubernetes: k,
-	}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected kubernetes account to be in clouddriver config, got %+v", gotC)
-	}
-}
-
-func TestEmptyArtifactsToHalConfig(t *testing.T) {
-	h := &config.Hal{
-		Artifacts: &artifact.Artifacts{},
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{
-		Artifacts: &artifact.Artifacts{},
-	}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected empty artifact providers to be passed to clouddriver config, got %+v", gotC)
-	}
-}
-
-func TestEmptyGcsArtifactConfigToHalConfig(t *testing.T) {
-	a := &artifact.Artifacts{
-		Gcs: &artifact.Gcs{},
-	}
-	h := &config.Hal{
-		Artifacts: a,
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{
-		Artifacts: a,
-	}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected empty GCS artifact config to be passed to clouddriver config, got %+v", gotC)
-	}
-}
-
-func TestGcsArtifactAccountToHalConfig(t *testing.T) {
-	a := &artifact.Artifacts{
-		Gcs: &artifact.Gcs{
-			Enabled: true,
-			Accounts: []*artifact.GcsAccount{
-				{
-					Name:     "my-account",
-					JsonPath: "/var/secrets/my-key.json",
+	},
+	{
+		"Kubernetes account",
+		&config.Hal{
+			Providers: &config.Hal_Providers{
+				Kubernetes: &cloudprovider.Kubernetes{
+					Enabled: true,
+					Accounts: []*cloudprovider.KubernetesAccount{
+						{
+							Name:           "my-account",
+							Kinds:          []string{"deployment"},
+							OmitNamespaces: []string{"kube-system"},
+						},
+					},
+					PrimaryAccount: "my-account",
 				},
 			},
 		},
-	}
-	h := &config.Hal{
-		Artifacts: a,
-	}
-	gotC := HalToClouddriver(h)
-	wantC := &config.Clouddriver{
-		Artifacts: a,
-	}
-	if !reflect.DeepEqual(gotC, wantC) {
-		t.Errorf("Expected GCS artifact config to be passed to clouddriver config, got %+v", gotC)
-	}
-}
-
-func TestEmptyHalConfigToEcho(t *testing.T) {
-	h := &config.Hal{}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
-	}
-}
-
-func TestEmptyNotificationsToEchoConfig(t *testing.T) {
-	h := &config.Hal{
-		Notifications: &notification.Notifications{},
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty hal config to generate empty echo config, got %v", gotE)
-	}
-}
-
-func TestSlackNotificationToEchoConfig(t *testing.T) {
-	slack := &notification.Slack{
-		Enabled: true,
-		BotName: "my-bot",
-		Token:   "my-token",
-		BaseUrl: "https://slack.test/",
-	}
-	h := &config.Hal{
-		Notifications: &notification.Notifications{
-			Slack: slack,
-		},
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Slack: slack,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected slack notifications to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestEmptyPubsubsToEchoConfig(t *testing.T) {
-	h := &config.Hal{
-		Pubsub: &pubsub.Pubsub{},
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Pubsub: &pubsub.Pubsub{},
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty pubsubs to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestEmptyGooglePubsubToEchoConfig(t *testing.T) {
-	pubsub := &pubsub.Pubsub{
-		Google: &pubsub.Google{},
-	}
-	h := &config.Hal{
-		Pubsub: pubsub,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Pubsub: pubsub,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty Google pubsub config to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestGooglePubsubToEchoConfig(t *testing.T) {
-	pubsub := &pubsub.Pubsub{
-		Google: &pubsub.Google{
-			Subscriptions: []*pubsub.GoogleSubscriber{
-				{
-					Name:             "my-account",
-					Project:          "my-project",
-					SubscriptionName: "my-subscription",
-					JsonPath:         "/var/secrets/my-account.json",
-					MessageFormat:    pubsub.MessageFormat_GCS,
+		&config.Clouddriver{
+			Kubernetes: &cloudprovider.Kubernetes{
+				Enabled: true,
+				Accounts: []*cloudprovider.KubernetesAccount{
+					{
+						Name:           "my-account",
+						Kinds:          []string{"deployment"},
+						OmitNamespaces: []string{"kube-system"},
+					},
 				},
+				PrimaryAccount: "my-account",
 			},
-			Publishers: []*pubsub.GooglePublisher{
-				{
-					Name:      "my-account",
-					Project:   "my-project",
-					TopicName: "my-topic",
+		},
+	},
+	{
+		"Empty artifacts",
+		&config.Hal{
+			Artifacts: &artifact.Artifacts{},
+		},
+		&config.Clouddriver{
+			Artifacts: &artifact.Artifacts{},
+		},
+	},
+	{
+		"Empty GCS artifacts",
+		&config.Hal{
+			Artifacts: &artifact.Artifacts{
+				Gcs: &artifact.Gcs{},
+			},
+		},
+		&config.Clouddriver{
+			Artifacts: &artifact.Artifacts{
+				Gcs: &artifact.Gcs{},
+			},
+		},
+	},
+	{
+		"GCS artifact account",
+		&config.Hal{
+			Artifacts: &artifact.Artifacts{
+				Gcs: &artifact.Gcs{
+					Enabled: true,
+					Accounts: []*artifact.GcsAccount{
+						{
+							Name:     "my-account",
+							JsonPath: "/var/secrets/my-key.json",
+						},
+					},
 				},
 			},
 		},
-	}
-	h := &config.Hal{
-		Pubsub: pubsub,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Pubsub: pubsub,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected Google pubsub config to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestEmptyCiConfigToEcho(t *testing.T) {
-	h := &config.Hal{
-		Ci: &ci.Ci{},
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty CI config to lead to empty echo config, got %v", gotE)
-	}
-}
-
-func TestEmptyGcbConfigAccountToEcho(t *testing.T) {
-	gcb := &ci.GoogleCloudBuild{}
-	cis := &ci.Ci{
-		Gcb: gcb,
-	}
-	h := &config.Hal{
-		Ci: cis,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Gcb: gcb,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty Google pubsub config to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestGcbAccountToEcho(t *testing.T) {
-	gcb := &ci.GoogleCloudBuild{
-		Enabled: true,
-		Accounts: []*ci.GoogleCloudBuildAccount{
-			{
-				Name:             "my-account",
-				Project:          "my-project",
-				SubscriptionName: "my-subscription",
+		&config.Clouddriver{
+			Artifacts: &artifact.Artifacts{
+				Gcs: &artifact.Gcs{
+					Enabled: true,
+					Accounts: []*artifact.GcsAccount{
+						{
+							Name:     "my-account",
+							JsonPath: "/var/secrets/my-key.json",
+						},
+					},
+				},
 			},
 		},
-	}
-	cis := &ci.Ci{
-		Gcb: gcb,
-	}
-	h := &config.Hal{
-		Ci: cis,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Gcb: gcb,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected Google Cloud Build account to be passed through to echo config, got %v", gotE)
+	},
+}
+
+func TestHalToClouddriver(t *testing.T) {
+	for _, tt := range halToClouddriverTests {
+		t.Run(tt.n, func(t *testing.T) {
+			gotC := HalToClouddriver(tt.h)
+			if !reflect.DeepEqual(gotC, tt.wantC) {
+				t.Errorf("Expected hal config to generate %v, got %v", tt.wantC, gotC)
+			}
+		})
 	}
 }
 
-func TestEmptyStatsToEcho(t *testing.T) {
-	h := &config.Hal{
-		Stats: &client.Stats{},
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Stats: &client.Stats{},
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected empty stats config to be passed through to echo config, got %v", gotE)
-	}
+var halToEchoTests = []struct {
+	n     string
+	h     *config.Hal
+	wantE *config.Echo
+}{
+	{
+		"Empty hal config",
+		&config.Hal{},
+		&config.Echo{},
+	},
+	{
+		"Empty notifications",
+		&config.Hal{
+			Notifications: &notification.Notifications{},
+		},
+		&config.Echo{},
+	},
+	{
+		"Slack notification",
+		&config.Hal{
+			Notifications: &notification.Notifications{
+				Slack: &notification.Slack{
+					Enabled: true,
+					BotName: "my-bot",
+					Token:   "my-token",
+					BaseUrl: "https://slack.test/",
+				},
+			},
+		},
+		&config.Echo{
+			Slack: &notification.Slack{
+				Enabled: true,
+				BotName: "my-bot",
+				Token:   "my-token",
+				BaseUrl: "https://slack.test/",
+			},
+		},
+	},
+	{
+		"Empty pub/sub",
+		&config.Hal{
+			Pubsub: &pubsub.Pubsub{},
+		},
+		&config.Echo{
+			Pubsub: &pubsub.Pubsub{},
+		},
+	},
+	{
+		"Empty Google pub/sub",
+		&config.Hal{
+			Pubsub: &pubsub.Pubsub{
+				Google: &pubsub.Google{},
+			},
+		},
+		&config.Echo{
+			Pubsub: &pubsub.Pubsub{
+				Google: &pubsub.Google{},
+			},
+		},
+	},
+	{
+		"Google pub/sub",
+		&config.Hal{
+			Pubsub: &pubsub.Pubsub{
+				Google: &pubsub.Google{
+					Subscriptions: []*pubsub.GoogleSubscriber{
+						{
+							Name:             "my-account",
+							Project:          "my-project",
+							SubscriptionName: "my-subscription",
+							JsonPath:         "/var/secrets/my-account.json",
+							MessageFormat:    pubsub.MessageFormat_GCS,
+						},
+					},
+					Publishers: []*pubsub.GooglePublisher{
+						{
+							Name:      "my-account",
+							Project:   "my-project",
+							TopicName: "my-topic",
+						},
+					},
+				},
+			},
+		},
+		&config.Echo{
+			Pubsub: &pubsub.Pubsub{
+				Google: &pubsub.Google{
+					Subscriptions: []*pubsub.GoogleSubscriber{
+						{
+							Name:             "my-account",
+							Project:          "my-project",
+							SubscriptionName: "my-subscription",
+							JsonPath:         "/var/secrets/my-account.json",
+							MessageFormat:    pubsub.MessageFormat_GCS,
+						},
+					},
+					Publishers: []*pubsub.GooglePublisher{
+						{
+							Name:      "my-account",
+							Project:   "my-project",
+							TopicName: "my-topic",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		"Empty CI",
+		&config.Hal{
+			Ci: &ci.Ci{},
+		},
+		&config.Echo{},
+	},
+	{
+		"Empty GCB account",
+		&config.Hal{
+			Ci: &ci.Ci{
+				Gcb: &ci.GoogleCloudBuild{},
+			},
+		},
+		&config.Echo{
+			Gcb: &ci.GoogleCloudBuild{},
+		},
+	},
+	{
+		"GCB account",
+		&config.Hal{
+			Ci: &ci.Ci{
+				Gcb: &ci.GoogleCloudBuild{
+					Enabled: true,
+					Accounts: []*ci.GoogleCloudBuildAccount{
+						{
+							Name:             "my-account",
+							Project:          "my-project",
+							SubscriptionName: "my-subscription",
+						},
+					},
+				},
+			},
+		},
+		&config.Echo{
+			Gcb: &ci.GoogleCloudBuild{
+				Enabled: true,
+				Accounts: []*ci.GoogleCloudBuildAccount{
+					{
+						Name:             "my-account",
+						Project:          "my-project",
+						SubscriptionName: "my-subscription",
+					},
+				},
+			},
+		},
+	},
+	{
+		"Empty stats",
+		&config.Hal{
+			Stats: &client.Stats{},
+		},
+		&config.Echo{
+			Stats: &client.Stats{},
+		},
+	},
+	{
+		"Stats enabled",
+		&config.Hal{
+			Stats: &client.Stats{Enabled: true},
+		},
+		&config.Echo{
+			Stats: &client.Stats{Enabled: true},
+		},
+	},
+	{
+		"Stats disabled",
+		&config.Hal{
+			Stats: &client.Stats{Enabled: false},
+		},
+		&config.Echo{
+			Stats: &client.Stats{Enabled: false},
+		},
+	},
 }
 
-func TestStatsEnabledToEcho(t *testing.T) {
-	stats := &client.Stats{Enabled: true}
-	h := &config.Hal{
-		Stats: stats,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Stats: stats,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected enabled stats config to be passed through to echo config, got %v", gotE)
-	}
-}
-
-func TestStatsDisabledToEcho(t *testing.T) {
-	stats := &client.Stats{Enabled: false}
-	h := &config.Hal{
-		Stats: stats,
-	}
-	gotE := HalToEcho(h)
-	wantE := &config.Echo{
-		Stats: stats,
-	}
-	if !reflect.DeepEqual(gotE, wantE) {
-		t.Errorf("Expected disabled stats config to be passed through to echo config, got %v", gotE)
+func TestHalToEcho(t *testing.T) {
+	for _, tt := range halToEchoTests {
+		t.Run(tt.n, func(t *testing.T) {
+			gotC := HalToEcho(tt.h)
+			if !reflect.DeepEqual(gotC, tt.wantE) {
+				t.Errorf("Expected hal config to generate %v, got %v", tt.wantE, gotC)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This is a straw-PR. I'd actually like to suggest we write the inputs/outputs to all these tests as YAML for clarity, and have the inputs to these tests simply be a name, file of halconfig YAML, and file of output-service YAML. Let me know what you think!