### PR TITLE
feat(core): Mark .pb.go files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pb.go linguist-generated=true


### PR DESCRIPTION
This removes them from the github language stats.