### PR TITLE
fix(cmd): add validation for command line arguments

### DIFF
--- a/cmd/kleat/main.go
+++ b/cmd/kleat/main.go
@@ -16,12 +16,18 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spinnaker/kleat/internal/write"
 )
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "arguments must be <halPath> <dir>\n")
+		os.Exit(1)
+	}
+
 	hal := os.Args[1]
 	dir := os.Args[2]
 	if err := write.WriteConfigs(hal, dir); err != nil {


### PR DESCRIPTION
There's no validation of command line arguments, so panic occurs if the arguments are wrong.
