### PR TITLE
fix(deck): Use override URL for gate if specified

### DIFF
--- a/internal/write/write_configs.go
+++ b/internal/write/write_configs.go
@@ -67,6 +67,9 @@ func WriteConfigs(halPath string, dir string) error {
 	if err := write(services.GetRosco(), filepath.Join(dir, "rosco.yml")); err != nil {
 		return err
 	}
+	if err := write(services.GetDeck(), filepath.Join(dir, "deck.yml")); err != nil {
+		return err
+	}
 	if err := writeDeck(services.GetDeck(), filepath.Join(dir, "settings.js")); err != nil {
 		return err
 	}

--- a/internal/write/write_configs.go
+++ b/internal/write/write_configs.go
@@ -67,9 +67,6 @@ func WriteConfigs(halPath string, dir string) error {
 	if err := write(services.GetRosco(), filepath.Join(dir, "rosco.yml")); err != nil {
 		return err
 	}
-	if err := write(services.GetDeck(), filepath.Join(dir, "deck.yml")); err != nil {
-		return err
-	}
 	if err := writeDeck(services.GetDeck(), filepath.Join(dir, "settings.js")); err != nil {
 		return err
 	}

--- a/pkg/parse_hal/hal_to_deck.go
+++ b/pkg/parse_hal/hal_to_deck.go
@@ -40,11 +40,14 @@ func HalToDeck(h *config.Hal) *config.Deck {
 }
 
 func getGateUrl(h *config.Hal) string {
+	if override := h.GetSecurity().GetApiSecurity().GetOverrideBaseUrl(); override != "" {
+		return override
+	}
 	scheme := "http"
 	if h.GetSecurity().GetApiSecurity().GetSsl().GetEnabled() {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://gate.spinnaker:8084", scheme)
+	return fmt.Sprintf("%s://localhost:8084", scheme)
 }
 
 func getDeckCanaryConfig(h *config.Hal) *config.Deck_Canary {

--- a/pkg/parse_hal/hal_to_deck_test.go
+++ b/pkg/parse_hal/hal_to_deck_test.go
@@ -44,9 +44,9 @@ var halToDeckTests = []struct {
 		"Empty hal config",
 		&config.Hal{},
 		&config.Deck{
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -67,9 +67,9 @@ var halToDeckTests = []struct {
 			},
 		},
 		&config.Deck{
-			GateUrl:         "https://gate.spinnaker:8084",
-			AuthEndpoint:    "https://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "https://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "https://localhost:8084",
+			AuthEndpoint:    "https://localhost:8084/auth/user",
+			BakeryDetailUrl: "https://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -87,9 +87,9 @@ var halToDeckTests = []struct {
 		},
 		&config.Deck{
 			AuthEnabled:     true,
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -111,9 +111,9 @@ var halToDeckTests = []struct {
 			},
 		},
 		&config.Deck{
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				MetricsAccountName: "my-metrics-account",
 				MetricStore:        "datadog",
@@ -133,9 +133,9 @@ var halToDeckTests = []struct {
 		},
 		&config.Deck{
 			DefaultTimeZone: "America/Chicago",
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -155,9 +155,9 @@ var halToDeckTests = []struct {
 			},
 		},
 		&config.Deck{
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			// TODO: this test demonstrates less-than-ideal result of having
 			// multiple canary flags that users must enable: both canary.enabled
 			// and features.mineCanary must be set to true in order for the
@@ -185,9 +185,9 @@ var halToDeckTests = []struct {
 			},
 		},
 		&config.Deck{
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -217,9 +217,9 @@ var halToDeckTests = []struct {
 			},
 		},
 		&config.Deck{
-			GateUrl:         "http://gate.spinnaker:8084",
-			AuthEndpoint:    "http://gate.spinnaker:8084/auth/user",
-			BakeryDetailUrl: "http://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			GateUrl:         "http://localhost:8084",
+			AuthEndpoint:    "http://localhost:8084/auth/user",
+			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 			Canary: &config.Deck_Canary{
 				FeatureDisabled: true,
 			},
@@ -233,6 +233,27 @@ var halToDeckTests = []struct {
 					},
 				},
 			},
+		},
+	},
+	{
+		"Override gate URL",
+		&config.Hal{
+			Security: &security.Security{
+				ApiSecurity: &security.ApiSecurity{
+					OverrideBaseUrl: "https://spinnaker.test:8084",
+				},
+			},
+		},
+		&config.Deck{
+			GateUrl:         "https://spinnaker.test:8084",
+			AuthEndpoint:    "https://spinnaker.test:8084/auth/user",
+			BakeryDetailUrl: "https://spinnaker.test:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+			Canary: &config.Deck_Canary{
+				FeatureDisabled: true,
+			},
+			Features:      &config.Deck_Features{},
+			Notifications: &config.Deck_Notifications{},
+			Providers:     &config.Deck_Providers{},
 		},
 	},
 }

--- a/testdata/deck.yml
+++ b/testdata/deck.yml
@@ -1,6 +1,6 @@
 authEnabled: true
-authEndpoint: https://gate.spinnaker:8084/auth/user
-bakeryDetailUrl: https://gate.spinnaker:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}
+authEndpoint: https://spinnaker.test:8084/auth/user
+bakeryDetailUrl: https://spinnaker.test:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}
 canary:
   metricStore: stackdriver
   metricsAccountName: my-google-canary-account
@@ -13,7 +13,7 @@ features:
   fiatEnabled: true
   managedPipelineTemplatesV2UI: true
   pipelineTemplates: true
-gateUrl: https://gate.spinnaker:8084
+gateUrl: https://spinnaker.test:8084
 notifications:
   githubStatus:
     enabled: true


### PR DESCRIPTION
If an override URL for gate is specified, it should be used in the deck config.

Also, I updated the default URL to be localhost; as this is used to set a client-side URL it will be accessed from outside the cluster where the cluster-local address likely won't be routable. Setting this to localhost allows you to port forward to the cluster to access gate.

I'd imagine that anyone actually running a real instance has the override set (rather than forwarding) but I think localhost is probably a better default (and is what Halyard does).