### PR TITLE
refactor(core): Move config generation to core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ to document each new message and field. Ensure the field is included in the
 [hal config](/api/proto/config/halconfig.proto) and each
 consuming service's config.
 
-2. **Translate.** If necessary, update the code that [translates](/pkg/parse_hal/hal_to_service_configs.go)
+2. **Translate.** If necessary, update the code that [translates](/pkg/transform/transform.go)
 the hal config to each individual microservice's config. Add unit tests to the
 appropriate service config tests in the `parse_hal` package.
 

--- a/cmd/kleat/main.go
+++ b/cmd/kleat/main.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spinnaker/kleat/internal/write"
+	"github.com/spinnaker/kleat/internal/fileio"
 )
 
 func main() {
@@ -36,10 +36,10 @@ func main() {
 }
 
 func writeServiceConfigs(halPath string, dir string) error {
-	h, err := write.ParseHalConfig(halPath)
+	h, err := fileio.ParseHalConfig(halPath)
 	if err != nil {
 		return err
 	}
 
-	return write.WriteConfigs(h, dir)
+	return fileio.WriteConfigs(h, dir)
 }

--- a/internal/convert/clouddriver.go
+++ b/internal/convert/clouddriver.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
+package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 

--- a/internal/convert/clouddriver.go
+++ b/internal/convert/clouddriver.go
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToClouddriver generates the clouddriver config for the supplied config.Hal h.
 func HalToClouddriver(h *config.Hal) *config.Clouddriver {
 	return &config.Clouddriver{
 		Kubernetes:     h.GetProviders().GetKubernetes(),

--- a/internal/convert/clouddriver_test.go
+++ b/internal/convert/clouddriver_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/clouddriver_test.go
+++ b/internal/convert/clouddriver_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/artifact"
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -140,7 +140,7 @@ var halToClouddriverTests = []struct {
 func TestHalToClouddriver(t *testing.T) {
 	for _, tt := range halToClouddriverTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToClouddriver(tt.hal)
+			got := convert.HalToClouddriver(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/deck.go
+++ b/internal/convert/deck.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert
 
 import (
@@ -22,13 +23,14 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 )
 
+// HalToDeck generates the deck config for the supplied config.Hal h.
 func HalToDeck(h *config.Hal) *config.Deck {
-	gateUrl := getGateUrl(h)
+	gateURL := getGateURL(h)
 	return &config.Deck{
-		GateUrl:         gateUrl,
+		GateUrl:         gateURL,
 		AuthEnabled:     h.GetSecurity().GetAuthn().GetEnabled(),
-		AuthEndpoint:    gateUrl + "/auth/user",
-		BakeryDetailUrl: gateUrl + "/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+		AuthEndpoint:    gateURL + "/auth/user",
+		BakeryDetailUrl: gateURL + "/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
 		Canary:          getDeckCanaryConfig(h),
 		Changelog:       getDeckChangelogConfig(h),
 		DefaultTimeZone: h.GetTimezone(),
@@ -39,7 +41,7 @@ func HalToDeck(h *config.Hal) *config.Deck {
 	}
 }
 
-func getGateUrl(h *config.Hal) string {
+func getGateURL(h *config.Hal) string {
 	if override := h.GetSecurity().GetApiSecurity().GetOverrideBaseUrl(); override != "" {
 		return override
 	}

--- a/internal/convert/deck.go
+++ b/internal/convert/deck.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
+package convert
 
 import (
 	"fmt"

--- a/internal/convert/deck_env.go
+++ b/internal/convert/deck_env.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package parse_hal
+package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 

--- a/internal/convert/deck_env.go
+++ b/internal/convert/deck_env.go
@@ -18,6 +18,7 @@ package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToDeckEnv generates the deck environment config for the supplied config.Hal h.
 func HalToDeckEnv(h *config.Hal) *config.DeckEnv {
 	if !h.GetSecurity().GetUiSecurity().GetSsl().GetEnabled() {
 		return &config.DeckEnv{}

--- a/internal/convert/deck_env_test.go
+++ b/internal/convert/deck_env_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/deck_env_test.go
+++ b/internal/convert/deck_env_test.go
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/security"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -75,7 +75,7 @@ var halToDeckEnvTests = []struct {
 func TestHalToDeckEnv(t *testing.T) {
 	for _, tt := range halToDeckEnvTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToDeckEnv(tt.hal)
+			got := convert.HalToDeckEnv(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/deck_test.go
+++ b/internal/convert/deck_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/deck_test.go
+++ b/internal/convert/deck_test.go
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client/notification"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/spinnaker/kleat/api/client/security"
 
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -261,7 +261,7 @@ var halToDeckTests = []struct {
 func TestHalToDeck(t *testing.T) {
 	for _, tt := range halToDeckTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToDeck(tt.hal)
+			got := convert.HalToDeck(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/echo.go
+++ b/internal/convert/echo.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
+package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 

--- a/internal/convert/echo.go
+++ b/internal/convert/echo.go
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToEcho generates the echo config for the supplied config.Hal h.
 func HalToEcho(h *config.Hal) *config.Echo {
 	return &config.Echo{
 		Slack:        h.GetNotifications().GetSlack(),

--- a/internal/convert/echo_test.go
+++ b/internal/convert/echo_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/echo_test.go
+++ b/internal/convert/echo_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
@@ -24,7 +24,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/notification"
 	"github.com/spinnaker/kleat/api/client/pubsub"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -227,7 +227,7 @@ var halToEchoTests = []struct {
 func TestHalToEcho(t *testing.T) {
 	for _, tt := range halToEchoTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToEcho(tt.hal)
+			got := convert.HalToEcho(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/fiat.go
+++ b/internal/convert/fiat.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 )
 
+// HalToFiat generates the fiat config for the supplied config.Hal h.
 func HalToFiat(h *config.Hal) *config.Fiat {
 	return &config.Fiat{
 		Auth: h.GetSecurity().GetAuthz(),

--- a/internal/convert/fiat.go
+++ b/internal/convert/fiat.go
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
 
-import "github.com/spinnaker/kleat/api/client/config"
+package convert
 
-func HalToRosco(h *config.Hal) *config.Rosco {
-	return &config.Rosco{
-		Google:      h.GetProviders().GetGoogle(),
-		Aws:         h.GetProviders().GetAws(),
-		Azure:       h.GetProviders().GetAzure(),
-		Huaweicloud: h.GetProviders().GetHuaweicloud(),
-		Oracle:      h.GetProviders().GetOracle(),
+import (
+	"github.com/spinnaker/kleat/api/client/config"
+)
+
+func HalToFiat(h *config.Hal) *config.Fiat {
+	return &config.Fiat{
+		Auth: h.GetSecurity().GetAuthz(),
 	}
 }

--- a/internal/convert/fiat_test.go
+++ b/internal/convert/fiat_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/fiat_test.go
+++ b/internal/convert/fiat_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/security"
 	"github.com/spinnaker/kleat/api/client/security/authz"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -75,7 +75,7 @@ var halToFiatTests = []struct {
 func TestHalToFiat(t *testing.T) {
 	for _, tt := range halToFiatTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToFiat(tt.hal)
+			got := convert.HalToFiat(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/front50.go
+++ b/internal/convert/front50.go
@@ -18,6 +18,7 @@ package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToFront50 generates the front50 config for the supplied config.Hal h.
 func HalToFront50(h *config.Hal) *config.Front50 {
 	return &config.Front50{
 		Spinnaker: &config.Front50_Spinnaker{

--- a/internal/convert/front50.go
+++ b/internal/convert/front50.go
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package parse_hal
+package convert
 
-import (
-	"github.com/spinnaker/kleat/api/client/config"
-)
+import "github.com/spinnaker/kleat/api/client/config"
 
-func HalToFiat(h *config.Hal) *config.Fiat {
-	return &config.Fiat{
-		Auth: h.GetSecurity().GetAuthz(),
+func HalToFront50(h *config.Hal) *config.Front50 {
+	return &config.Front50{
+		Spinnaker: &config.Front50_Spinnaker{
+			Gcs:    h.GetPersistentStorage().GetGcs(),
+			Azs:    h.GetPersistentStorage().GetAzs(),
+			Oracle: h.GetPersistentStorage().GetOracle(),
+			S3:     h.GetPersistentStorage().GetS3(),
+		},
 	}
 }

--- a/internal/convert/front50_test.go
+++ b/internal/convert/front50_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/front50_test.go
+++ b/internal/convert/front50_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/storage"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -101,7 +101,7 @@ var halToFront50Tests = []struct {
 func TestHalToFront50(t *testing.T) {
 	for _, tt := range halToFront50Tests {
 		t.Run(tt.n, func(t *testing.T) {
-			got := parse_hal.HalToFront50(tt.h)
+			got := convert.HalToFront50(tt.h)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/gate.go
+++ b/internal/convert/gate.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package parse_hal
+package convert
 
 import (
 	"github.com/spinnaker/kleat/api/client/config"

--- a/internal/convert/gate.go
+++ b/internal/convert/gate.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// HalToGate generates the gate config for the supplied config.Hal h.
 func HalToGate(h *config.Hal) *config.Gate {
 	return &config.Gate{
 		Server:       getServerConfig(h),

--- a/internal/convert/gate_test.go
+++ b/internal/convert/gate_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/gate_test.go
+++ b/internal/convert/gate_test.go
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client/canary"
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/security"
 	"github.com/spinnaker/kleat/api/client/security/authn"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -287,7 +287,7 @@ var halToGateTests = []struct {
 func TestHalToGate(t *testing.T) {
 	for _, tt := range halToGateTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToGate(tt.hal)
+			got := convert.HalToGate(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/igor.go
+++ b/internal/convert/igor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 )
 
+// HalToIgor generates the igor config for the supplied config.Hal h.
 func HalToIgor(h *config.Hal) *config.Igor {
 	return &config.Igor{
 		Artifactory:    h.GetRepository().GetArtifactory(),

--- a/internal/convert/igor.go
+++ b/internal/convert/igor.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package parse_hal
+package convert
 
 import (
 	"github.com/spinnaker/kleat/api/client/config"

--- a/internal/convert/igor_test.go
+++ b/internal/convert/igor_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/igor_test.go
+++ b/internal/convert/igor_test.go
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/ci"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client/repository"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -160,7 +160,7 @@ var halToIgorTests = []struct {
 func TestHalToIgor(t *testing.T) {
 	for _, tt := range halToIgorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToIgor(tt.hal)
+			got := convert.HalToIgor(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/kayenta.go
+++ b/internal/convert/kayenta.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 )
 
+// HalToKayenta generates the kayanta config for the supplied config.Hal h.
 func HalToKayenta(h *config.Hal) *config.Kayenta {
 	if !h.GetCanary().GetEnabled() {
 		return &config.Kayenta{}

--- a/internal/convert/kayenta.go
+++ b/internal/convert/kayenta.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package parse_hal
+package convert
 
 import (
 	"github.com/spinnaker/kleat/api/client/canary"

--- a/internal/convert/kayenta_test.go
+++ b/internal/convert/kayenta_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/kayenta_test.go
+++ b/internal/convert/kayenta_test.go
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/canary"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -341,7 +341,7 @@ var halToKayentaTests = []struct {
 func TestHalToKayenta(t *testing.T) {
 	for _, tt := range halToKayentaTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToKayenta(tt.hal)
+			got := convert.HalToKayenta(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/orca.go
+++ b/internal/convert/orca.go
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToOrca generates the orca config for the supplied config.Hal h.
 func HalToOrca(h *config.Hal) *config.Orca {
 	return &config.Orca{
 		Default:           getDefaults(h),

--- a/internal/convert/orca.go
+++ b/internal/convert/orca.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
+package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 

--- a/internal/convert/orca_test.go
+++ b/internal/convert/orca_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/convert/orca_test.go
+++ b/internal/convert/orca_test.go
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/canary"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client"
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/api/client/security"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -140,7 +140,7 @@ var halToOrcaTests = []struct {
 func TestHalToOrca(t *testing.T) {
 	for _, tt := range halToOrcaTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToOrca(tt.hal)
+			got := convert.HalToOrca(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/rosco.go
+++ b/internal/convert/rosco.go
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
+// HalToRosco generates the rosco config for the supplied config.Hal h.
 func HalToRosco(h *config.Hal) *config.Rosco {
 	return &config.Rosco{
 		Google:      h.GetProviders().GetGoogle(),

--- a/internal/convert/rosco.go
+++ b/internal/convert/rosco.go
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package parse_hal
+package convert
 
 import "github.com/spinnaker/kleat/api/client/config"
 
-func HalToFront50(h *config.Hal) *config.Front50 {
-	return &config.Front50{
-		Spinnaker: &config.Front50_Spinnaker{
-			Gcs:    h.GetPersistentStorage().GetGcs(),
-			Azs:    h.GetPersistentStorage().GetAzs(),
-			Oracle: h.GetPersistentStorage().GetOracle(),
-			S3:     h.GetPersistentStorage().GetS3(),
-		},
+func HalToRosco(h *config.Hal) *config.Rosco {
+	return &config.Rosco{
+		Google:      h.GetProviders().GetGoogle(),
+		Aws:         h.GetProviders().GetAws(),
+		Azure:       h.GetProviders().GetAzure(),
+		Huaweicloud: h.GetProviders().GetHuaweicloud(),
+		Oracle:      h.GetProviders().GetOracle(),
 	}
 }

--- a/internal/convert/rosco_test.go
+++ b/internal/convert/rosco_test.go
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package convert_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/internal/convert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -139,7 +139,7 @@ var halToRoscoTests = []struct {
 func TestHalToRosco(t *testing.T) {
 	for _, tt := range halToRoscoTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parse_hal.HalToRosco(tt.hal)
+			got := convert.HalToRosco(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/rosco_test.go
+++ b/internal/convert/rosco_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package convert_test
 
 import (

--- a/internal/fileio/fileio.go
+++ b/internal/fileio/fileio.go
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package write
+
+// Package fileio supports reading reading and writing config files to the
+// filesystem.
+package fileio
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,6 +30,9 @@ import (
 	"github.com/spinnaker/kleat/pkg/validate"
 )
 
+// ParseHalConfig reads the YAML file at halPath parses it into a *config.Hal.
+// The config.Hal is validated; if there are any errors, they will be returned
+// in error and *config.Hal will be nil.
 func ParseHalConfig(halPath string) (*config.Hal, error) {
 	data, err := ioutil.ReadFile(halPath)
 	if err != nil {
@@ -46,6 +51,8 @@ func ParseHalConfig(halPath string) (*config.Hal, error) {
 	return hal, nil
 }
 
+// WriteConfigs generates the service configs from the supplied hal, and writes
+// them to the directory dir.
 func WriteConfigs(hal *config.Hal, dir string) error {
 	if err := ensureDirectory(dir); err != nil {
 		return err
@@ -72,7 +79,7 @@ func ensureDirectory(d string) error {
 		return err
 	}
 	if !stat.IsDir() {
-		return errors.New(fmt.Sprintf("%s is not a directory", d))
+		return fmt.Errorf("%s is not a directory", d)
 	}
 	return nil
 }

--- a/internal/protoyaml/protoyaml.go
+++ b/internal/protoyaml/protoyaml.go
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package protoyaml marshals and unmarshals protocol buffer messages in YAML
+// format.
 package protoyaml
 
 import (
@@ -24,6 +27,7 @@ import (
 var nonStrict = protojson.UnmarshalOptions{DiscardUnknown: true}
 var strict = protojson.UnmarshalOptions{DiscardUnknown: false}
 
+// Marshal writes the given proto.Message in YAML format.
 func Marshal(m proto.Message) ([]byte, error) {
 	json, err := protojson.Marshal(m)
 	if err != nil {
@@ -32,6 +36,8 @@ func Marshal(m proto.Message) ([]byte, error) {
 	return yaml.JSONToYAML(json)
 }
 
+// Unmarshal reads the given []byte into the given proto.Message, discarding
+// any unknown fields in the input.
 func Unmarshal(b []byte, m proto.Message) error {
 	json, err := yaml.YAMLToJSON(b)
 	if err != nil {
@@ -40,6 +46,8 @@ func Unmarshal(b []byte, m proto.Message) error {
 	return nonStrict.Unmarshal(json, m)
 }
 
+// UnmarshalStrict reads the given []byte into the given proto.Message. If there
+// are any unknown fields in the input, an error is returned.
 func UnmarshalStrict(b []byte, m proto.Message) error {
 	json, err := yaml.YAMLToJSON(b)
 	if err != nil {

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -45,8 +45,8 @@ func (yaml) Serialize(m proto.Message) ([]byte, error) {
 
 type settingsJs struct{}
 
-// SettingsJs is a Serializer that serializes a proto.Message by outputting a JavaScript file to be consumed by Deck
-// .
+// SettingsJs is a Serializer that serializes a proto.Message by outputting a
+// JavaScript file to be consumed by Deck.
 var SettingsJs Serializer = new(settingsJs)
 
 func (settingsJs) Serialize(m proto.Message) ([]byte, error) {

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -45,7 +45,7 @@ func (yaml) Serialize(m proto.Message) ([]byte, error) {
 
 type settingsJs struct{}
 
-// SettingsJs is a Serializer that serializes a proto.Message by outputting a
+// SettingsJs is a Serializer that serializes a proto.Message by outputting a JavaScript file to be consumed by Deck
 // .
 var SettingsJs Serializer = new(settingsJs)
 

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package serializer provides functionality for serializing protocol buffer
+// messages into different formats.
 package serializer
 
 import (
@@ -25,12 +28,15 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+// Serializer is an interface that wraps a method to serialize a proto.Message
+// to a []byte.
 type Serializer interface {
 	Serialize(proto.Message) ([]byte, error)
 }
 
 type yaml struct{}
 
+// Yaml is a Serializer that serializes a proto.Message in YAML format.
 var Yaml Serializer = new(yaml)
 
 func (yaml) Serialize(m proto.Message) ([]byte, error) {
@@ -39,6 +45,8 @@ func (yaml) Serialize(m proto.Message) ([]byte, error) {
 
 type settingsJs struct{}
 
+// SettingsJs is a Serializer that serializes a proto.Message by outputting a
+// .
 var SettingsJs Serializer = new(settingsJs)
 
 func (settingsJs) Serialize(m proto.Message) ([]byte, error) {
@@ -57,6 +65,11 @@ func (settingsJs) Serialize(m proto.Message) ([]byte, error) {
 
 type envFile struct{}
 
+// EnvFile is a Serializer that serializes a proto.message as an environment
+// variable file.
+// For each top-level key in the message, a line key=value is appended to the
+// output, where key is the field's JSON name and value is the string string
+// representation of the field's value.
 var EnvFile Serializer = new(envFile)
 
 func (envFile) Serialize(m proto.Message) ([]byte, error) {

--- a/internal/write/write_configs.go
+++ b/internal/write/write_configs.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/internal/protoyaml"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
-	"github.com/spinnaker/kleat/pkg/validate_hal"
+	"github.com/spinnaker/kleat/pkg/transform"
+	"github.com/spinnaker/kleat/pkg/validate"
 )
 
 func ParseHalConfig(halPath string) (*config.Hal, error) {
@@ -39,7 +39,7 @@ func ParseHalConfig(halPath string) (*config.Hal, error) {
 		return nil, err
 	}
 
-	if err := validate_hal.ValidateHalConfig(hal); err != nil {
+	if err := validate.ValidateHalConfig(hal); err != nil {
 		return nil, err
 	}
 
@@ -51,8 +51,8 @@ func WriteConfigs(hal *config.Hal, dir string) error {
 		return err
 	}
 
-	services := parse_hal.HalToServiceConfigs(hal)
-	configFiles, err := parse_hal.GenerateConfigFiles(services)
+	services := transform.HalToServiceConfigs(hal)
+	configFiles, err := transform.GenerateConfigFiles(services)
 	if err != nil {
 		return err
 	}

--- a/pkg/parse_hal/hal_to_service_configs.go
+++ b/pkg/parse_hal/hal_to_service_configs.go
@@ -17,23 +17,24 @@ package parse_hal
 
 import (
 	"github.com/spinnaker/kleat/api/client/config"
+	"github.com/spinnaker/kleat/internal/convert"
 	"github.com/spinnaker/kleat/internal/serializer"
 	"google.golang.org/protobuf/proto"
 )
 
 func HalToServiceConfigs(h *config.Hal) *config.Services {
 	return &config.Services{
-		Clouddriver: HalToClouddriver(h),
-		Echo:        HalToEcho(h),
-		Front50:     HalToFront50(h),
-		Orca:        HalToOrca(h),
-		Gate:        HalToGate(h),
-		Fiat:        HalToFiat(h),
-		Kayenta:     HalToKayenta(h),
-		Rosco:       HalToRosco(h),
-		Deck:        HalToDeck(h),
-		DeckEnv:     HalToDeckEnv(h),
-		Igor:        HalToIgor(h),
+		Clouddriver: convert.HalToClouddriver(h),
+		Echo:        convert.HalToEcho(h),
+		Front50:     convert.HalToFront50(h),
+		Orca:        convert.HalToOrca(h),
+		Gate:        convert.HalToGate(h),
+		Fiat:        convert.HalToFiat(h),
+		Kayenta:     convert.HalToKayenta(h),
+		Rosco:       convert.HalToRosco(h),
+		Deck:        convert.HalToDeck(h),
+		DeckEnv:     convert.HalToDeckEnv(h),
+		Igor:        convert.HalToIgor(h),
 	}
 }
 

--- a/pkg/parse_hal/hal_to_service_configs_test.go
+++ b/pkg/parse_hal/hal_to_service_configs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/kylelemons/godebug/diff"
+	"github.com/spinnaker/kleat/internal/convert"
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/internal/protoyaml"
@@ -43,17 +44,17 @@ func TestHalToServiceConfigs(t *testing.T) {
 
 	gotS := parse_hal.HalToServiceConfigs(h)
 	wantS := &config.Services{
-		Clouddriver: parse_hal.HalToClouddriver(h),
-		Echo:        parse_hal.HalToEcho(h),
-		Front50:     parse_hal.HalToFront50(h),
-		Orca:        parse_hal.HalToOrca(h),
-		Gate:        parse_hal.HalToGate(h),
-		Fiat:        parse_hal.HalToFiat(h),
-		Kayenta:     parse_hal.HalToKayenta(h),
-		Rosco:       parse_hal.HalToRosco(h),
-		Deck:        parse_hal.HalToDeck(h),
-		DeckEnv:     parse_hal.HalToDeckEnv(h),
-		Igor:        parse_hal.HalToIgor(h),
+		Clouddriver: convert.HalToClouddriver(h),
+		Echo:        convert.HalToEcho(h),
+		Front50:     convert.HalToFront50(h),
+		Orca:        convert.HalToOrca(h),
+		Gate:        convert.HalToGate(h),
+		Fiat:        convert.HalToFiat(h),
+		Kayenta:     convert.HalToKayenta(h),
+		Rosco:       convert.HalToRosco(h),
+		Deck:        convert.HalToDeck(h),
+		DeckEnv:     convert.HalToDeckEnv(h),
+		Igor:        convert.HalToIgor(h),
 	}
 
 	if !proto.Equal(gotS, wantS) {

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal
+package transform
 
 import (
 	"github.com/spinnaker/kleat/api/client/config"

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parse_hal_test
+package transform_test
 
 import (
 	"bytes"
@@ -26,7 +26,7 @@ import (
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/internal/protoyaml"
-	"github.com/spinnaker/kleat/pkg/parse_hal"
+	"github.com/spinnaker/kleat/pkg/transform"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -42,7 +42,7 @@ func TestHalToServiceConfigs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotS := parse_hal.HalToServiceConfigs(h)
+	gotS := transform.HalToServiceConfigs(h)
 	wantS := &config.Services{
 		Clouddriver: convert.HalToClouddriver(h),
 		Echo:        convert.HalToEcho(h),
@@ -73,7 +73,7 @@ func TestHalToServiceYAML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	services := parse_hal.HalToServiceConfigs(hal)
+	services := transform.HalToServiceConfigs(hal)
 
 	var halToServiceTests = []struct {
 		file      string

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package validate_hal
+package validate
 
 import (
 	"errors"

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package validate_hal_test
+package validate_test
 
 import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/validate_hal"
+	"github.com/spinnaker/kleat/pkg/validate"
 )
 
 func TestEmptyHalConfig(t *testing.T) {
 	h := &config.Hal{}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -35,7 +35,7 @@ func TestEmptyProviders(t *testing.T) {
 	h := &config.Hal{
 		Providers: &cloudprovider.Providers{},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -47,7 +47,7 @@ func TestEmptyKubernetes(t *testing.T) {
 			Kubernetes: &cloudprovider.Kubernetes{},
 		},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -62,7 +62,7 @@ func TestNoKubernetesAccounts(t *testing.T) {
 			},
 		},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -81,7 +81,7 @@ func TestKuberntesAccountWithNoOmitKinds(t *testing.T) {
 			},
 		},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -101,7 +101,7 @@ func TestKuberntesAccountWithEmptyOmitKinds(t *testing.T) {
 			},
 		},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -121,7 +121,7 @@ func TestInvalidKubernetesAccount(t *testing.T) {
 			},
 		},
 	}
-	err := validate_hal.ValidateHalConfig(h)
+	err := validate.ValidateHalConfig(h)
 	if err == nil {
 		t.Error("Expected a validation failure, got none")
 	}


### PR DESCRIPTION
* refactor(core): Move config generation to core

  Until we find a valid use case for clients needing to individually generate service configs, let's move the code to generate the individual configs to the internal/ folder, and only expose the top-level functions for generating all configs.

  Let's also shorten the name of all of the hal_to_* files.

* refactor(core): Rename parse_hal and validate_hal

  Partly this is because go discourages package names including underscores
  (excluding _test packages). In the case of parse_hal, rename it transform as it's primarily used to transform protos.

* refactor(core): Add godoc and fix lint errors

  This commit adds godoc to all packages in internal/. As part of this it adds a newline before the copyright and the package name as I learned that otherwise the copyright statement is interpreted as a package-level comment.

  Most of the lint errors in this directory were just missing comments, but fixed a couple of other things (in particular capitalizing URL).

  Also rename a couple of packages to be less verbose.