### PR TITLE
test(core): Improve debuggability of unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/golang/protobuf v1.4.1
+	github.com/google/go-cmp v0.4.0
 	github.com/kylelemons/godebug v1.1.0
 	google.golang.org/protobuf v1.22.0
 	sigs.k8s.io/yaml v1.2.0

--- a/internal/convert/clouddriver_test.go
+++ b/internal/convert/clouddriver_test.go
@@ -26,11 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToClouddriverTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Clouddriver
-}{
+var clouddriverTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -139,7 +135,7 @@ var halToClouddriverTests = []struct {
 }
 
 func TestHalToClouddriver(t *testing.T) {
-	for _, tt := range halToClouddriverTests {
+	for _, tt := range clouddriverTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToClouddriver(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/clouddriver_test.go
+++ b/internal/convert/clouddriver_test.go
@@ -138,12 +138,5 @@ var clouddriverTests = configTest{
 }
 
 func TestHalToClouddriver(t *testing.T) {
-	for _, tt := range clouddriverTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := clouddriverTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, clouddriverTests)
 }

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright The Spinnaker Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package convert_test
+
+import (
+	"github.com/spinnaker/kleat/api/client/config"
+	"google.golang.org/protobuf/proto"
+)
+
+// testCase represents a test case for config generation, indicating
+// that we expect the supplied *config.Hal hal to be converted into the supplied
+// proto.Message want.
+type testCase struct {
+	name string
+	hal  *config.Hal
+	want proto.Message
+}

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -17,6 +17,8 @@
 package convert_test
 
 import (
+	"testing"
+
 	"github.com/spinnaker/kleat/api/client/config"
 	"google.golang.org/protobuf/proto"
 )
@@ -35,4 +37,15 @@ type testCase struct {
 type configTest struct {
 	generator func(h *config.Hal) proto.Message
 	tests     []testCase
+}
+
+func runConfigTest(t *testing.T, test configTest) {
+	for _, tt := range test.tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := test.generator(tt.hal)
+			if !proto.Equal(got, tt.want) {
+				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
+			}
+		})
+	}
 }

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -29,3 +29,10 @@ type testCase struct {
 	hal  *config.Hal
 	want proto.Message
 }
+
+// configTest represents a set of test on a config generator. The supplied
+// generator will be used for each of the supplied tests.
+type configTest struct {
+	generator func(h *config.Hal) proto.Message
+	tests     []testCase
+}

--- a/internal/convert/deck_env_test.go
+++ b/internal/convert/deck_env_test.go
@@ -25,54 +25,57 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var deckEnvTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.DeckEnv{},
-	},
-	{
-		"SSL disabled",
-		&config.Hal{
-			Security: &security.Security{
-				UiSecurity: &security.UiSecurity{
-					Ssl: &security.UiSsl{
-						Enabled:                  false,
-						SslCertificateFile:       "/var/secrets/cert.crt",
-						SslCertificateKeyFile:    "/var/secrets/cert.key",
-						SslCertificatePassphrase: "passw0rd",
+var deckEnvTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToDeckEnv(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.DeckEnv{},
+		},
+		{
+			"SSL disabled",
+			&config.Hal{
+				Security: &security.Security{
+					UiSecurity: &security.UiSecurity{
+						Ssl: &security.UiSsl{
+							Enabled:                  false,
+							SslCertificateFile:       "/var/secrets/cert.crt",
+							SslCertificateKeyFile:    "/var/secrets/cert.key",
+							SslCertificatePassphrase: "passw0rd",
+						},
 					},
 				},
 			},
+			&config.DeckEnv{},
 		},
-		&config.DeckEnv{},
-	},
-	{
-		"SSL configured",
-		&config.Hal{
-			Security: &security.Security{
-				UiSecurity: &security.UiSecurity{
-					Ssl: &security.UiSsl{
-						Enabled:                  true,
-						SslCertificateFile:       "/var/secrets/cert.crt",
-						SslCertificateKeyFile:    "/var/secrets/cert.key",
-						SslCertificatePassphrase: "passw0rd",
+		{
+			"SSL configured",
+			&config.Hal{
+				Security: &security.Security{
+					UiSecurity: &security.UiSecurity{
+						Ssl: &security.UiSsl{
+							Enabled:                  true,
+							SslCertificateFile:       "/var/secrets/cert.crt",
+							SslCertificateKeyFile:    "/var/secrets/cert.key",
+							SslCertificatePassphrase: "passw0rd",
+						},
 					},
 				},
 			},
-		},
-		&config.DeckEnv{
-			DeckCert:   "/var/secrets/cert.crt",
-			DeckKey:    "/var/secrets/cert.key",
-			Passphrase: "passw0rd",
+			&config.DeckEnv{
+				DeckCert:   "/var/secrets/cert.crt",
+				DeckKey:    "/var/secrets/cert.key",
+				Passphrase: "passw0rd",
+			},
 		},
 	},
 }
 
 func TestHalToDeckEnv(t *testing.T) {
-	for _, tt := range deckEnvTests {
+	for _, tt := range deckEnvTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToDeckEnv(tt.hal)
+			got := deckEnvTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/deck_env_test.go
+++ b/internal/convert/deck_env_test.go
@@ -25,11 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToDeckEnvTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.DeckEnv
-}{
+var deckEnvTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -74,7 +70,7 @@ var halToDeckEnvTests = []struct {
 }
 
 func TestHalToDeckEnv(t *testing.T) {
-	for _, tt := range halToDeckEnvTests {
+	for _, tt := range deckEnvTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToDeckEnv(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/deck_env_test.go
+++ b/internal/convert/deck_env_test.go
@@ -73,12 +73,5 @@ var deckEnvTests = configTest{
 }
 
 func TestHalToDeckEnv(t *testing.T) {
-	for _, tt := range deckEnvTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := deckEnvTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, deckEnvTests)
 }

--- a/internal/convert/deck_test.go
+++ b/internal/convert/deck_test.go
@@ -258,12 +258,5 @@ var deckTests = configTest{
 }
 
 func TestHalToDeck(t *testing.T) {
-	for _, tt := range deckTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := deckTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, deckTests)
 }

--- a/internal/convert/deck_test.go
+++ b/internal/convert/deck_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
-	"github.com/spinnaker/kleat/internal/convert"
-
 	"github.com/spinnaker/kleat/api/client/notification"
+	"github.com/spinnaker/kleat/internal/convert"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/spinnaker/kleat/api/client"
 
@@ -33,232 +33,234 @@ import (
 	"github.com/spinnaker/kleat/api/client/security"
 
 	"github.com/spinnaker/kleat/api/client/config"
-	"google.golang.org/protobuf/proto"
 )
 
-var deckTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Deck{
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
+var deckTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToDeck(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Deck{
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
 			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
 		},
-	},
-	{
-		"SSL enabled",
-		&config.Hal{
-			Security: &security.Security{
-				ApiSecurity: &security.ApiSecurity{
-					Ssl: &security.ApiSsl{
+		{
+			"SSL enabled",
+			&config.Hal{
+				Security: &security.Security{
+					ApiSecurity: &security.ApiSecurity{
+						Ssl: &security.ApiSsl{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			&config.Deck{
+				GateUrl:         "https://localhost:8084",
+				AuthEndpoint:    "https://localhost:8084/auth/user",
+				BakeryDetailUrl: "https://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
+			},
+		},
+		{
+			"Authn enabled",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{Enabled: true},
+				},
+			},
+			&config.Deck{
+				AuthEnabled:     true,
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
+			},
+		},
+		{
+			"Canary configured",
+			&config.Hal{
+				Canary: &canary.Canary{
+					Enabled:               true,
+					DefaultMetricsAccount: "my-metrics-account",
+					DefaultMetricsStore:   "datadog",
+					ShowAllConfigsEnabled: true,
+					TemplatesEnabled:      true,
+					StorageAccountName:    "my-storage-account",
+				},
+			},
+			&config.Deck{
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					MetricsAccountName: "my-metrics-account",
+					MetricStore:        "datadog",
+					ShowAllConfigs:     true,
+					StorageAccountName: "my-storage-account",
+					TemplatesEnabled:   true,
+				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
+			},
+		},
+		{
+			"Timezone configured",
+			&config.Hal{
+				Timezone: "America/Chicago",
+			},
+			&config.Deck{
+				DefaultTimeZone: "America/Chicago",
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
+			},
+		},
+		{
+			"Features configured",
+			&config.Hal{
+				Features: &client.Features{
+					PipelineTemplates:            true,
+					MineCanary:                   true,
+					Chaos:                        true,
+					ManagedPipelineTemplatesV2UI: true,
+				},
+			},
+			&config.Deck{
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				// TODO: this test demonstrates less-than-ideal result of having
+				// multiple canary flags that users must enable: both canary.enabled
+				// and features.mineCanary must be set to true in order for the
+				// canary UI and Kayenta to work properly.
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature: &config.Deck_Features{
+					PipelineTemplates:            true,
+					ManagedPipelineTemplatesV2UI: true,
+					ChaosMonkey:                  true,
+					Canary:                       true,
+				},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
+			},
+		},
+		{
+			"Notifications configured",
+			&config.Hal{
+				Notifications: &notification.Notifications{
+					Twilio: &notification.Twilio{
 						Enabled: true,
 					},
 				},
 			},
-		},
-		&config.Deck{
-			GateUrl:         "https://localhost:8084",
-			AuthEndpoint:    "https://localhost:8084/auth/user",
-			BakeryDetailUrl: "https://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
-		},
-	},
-	{
-		"Authn enabled",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{Enabled: true},
+			&config.Deck{
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
+				},
+				Feature: &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{
+					Sms: &notification.Twilio{
+						Enabled: true,
+					},
+				},
+				Providers: &config.Deck_Providers{},
 			},
 		},
-		&config.Deck{
-			AuthEnabled:     true,
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
-		},
-	},
-	{
-		"Canary configured",
-		&config.Hal{
-			Canary: &canary.Canary{
-				Enabled:               true,
-				DefaultMetricsAccount: "my-metrics-account",
-				DefaultMetricsStore:   "datadog",
-				ShowAllConfigsEnabled: true,
-				TemplatesEnabled:      true,
-				StorageAccountName:    "my-storage-account",
-			},
-		},
-		&config.Deck{
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				MetricsAccountName: "my-metrics-account",
-				MetricStore:        "datadog",
-				ShowAllConfigs:     true,
-				StorageAccountName: "my-storage-account",
-				TemplatesEnabled:   true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
-		},
-	},
-	{
-		"Timezone configured",
-		&config.Hal{
-			Timezone: "America/Chicago",
-		},
-		&config.Deck{
-			DefaultTimeZone: "America/Chicago",
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
-		},
-	},
-	{
-		"Features configured",
-		&config.Hal{
-			Features: &client.Features{
-				PipelineTemplates:            true,
-				MineCanary:                   true,
-				Chaos:                        true,
-				ManagedPipelineTemplatesV2UI: true,
-			},
-		},
-		&config.Deck{
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			// TODO: this test demonstrates less-than-ideal result of having
-			// multiple canary flags that users must enable: both canary.enabled
-			// and features.mineCanary must be set to true in order for the
-			// canary UI and Kayenta to work properly.
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature: &config.Deck_Features{
-				PipelineTemplates:            true,
-				ManagedPipelineTemplatesV2UI: true,
-				ChaosMonkey:                  true,
-				Canary:                       true,
-			},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
-		},
-	},
-	{
-		"Notifications configured",
-		&config.Hal{
-			Notifications: &notification.Notifications{
-				Twilio: &notification.Twilio{
-					Enabled: true,
+		{
+			"Provider defaults",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Google: &cloudprovider.GoogleComputeEngine{
+						Enabled: true,
+						Accounts: []*cloudprovider.GoogleComputeEngineAccount{
+							{
+								Name:    "my-gce-account",
+								Regions: []string{"us-east1", "us-east2"},
+							},
+						},
+						PrimaryAccount: "my-gce-account",
+					},
 				},
 			},
-		},
-		&config.Deck{
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature: &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{
-				Sms: &notification.Twilio{
-					Enabled: true,
+			&config.Deck{
+				GateUrl:         "http://localhost:8084",
+				AuthEndpoint:    "http://localhost:8084/auth/user",
+				BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
 				},
-			},
-			Providers: &config.Deck_Providers{},
-		},
-	},
-	{
-		"Provider defaults",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
-				Google: &cloudprovider.GoogleComputeEngine{
-					Enabled: true,
-					Accounts: []*cloudprovider.GoogleComputeEngineAccount{
-						{
-							Name:    "my-gce-account",
-							Regions: []string{"us-east1", "us-east2"},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers: &config.Deck_Providers{
+					Gce: &config.Deck_Providers_Gce{
+						Defaults: &config.Deck_Providers_Gce_Defaults{
+							Account: "my-gce-account",
+							Region:  "us-east1",
 						},
 					},
-					PrimaryAccount: "my-gce-account",
 				},
 			},
 		},
-		&config.Deck{
-			GateUrl:         "http://localhost:8084",
-			AuthEndpoint:    "http://localhost:8084/auth/user",
-			BakeryDetailUrl: "http://localhost:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers: &config.Deck_Providers{
-				Gce: &config.Deck_Providers_Gce{
-					Defaults: &config.Deck_Providers_Gce_Defaults{
-						Account: "my-gce-account",
-						Region:  "us-east1",
+		{
+			"Override gate URL",
+			&config.Hal{
+				Security: &security.Security{
+					ApiSecurity: &security.ApiSecurity{
+						OverrideBaseUrl: "https://spinnaker.test:8084",
 					},
 				},
 			},
-		},
-	},
-	{
-		"Override gate URL",
-		&config.Hal{
-			Security: &security.Security{
-				ApiSecurity: &security.ApiSecurity{
-					OverrideBaseUrl: "https://spinnaker.test:8084",
+			&config.Deck{
+				GateUrl:         "https://spinnaker.test:8084",
+				AuthEndpoint:    "https://spinnaker.test:8084/auth/user",
+				BakeryDetailUrl: "https://spinnaker.test:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
+				Canary: &config.Deck_Canary{
+					FeatureDisabled: true,
 				},
+				Feature:       &config.Deck_Features{},
+				Notifications: &config.Deck_Notifications{},
+				Providers:     &config.Deck_Providers{},
 			},
-		},
-		&config.Deck{
-			GateUrl:         "https://spinnaker.test:8084",
-			AuthEndpoint:    "https://spinnaker.test:8084/auth/user",
-			BakeryDetailUrl: "https://spinnaker.test:8084/bakery/logs/{{context.region}}/{{context.status.resourceId}}",
-			Canary: &config.Deck_Canary{
-				FeatureDisabled: true,
-			},
-			Feature:       &config.Deck_Features{},
-			Notifications: &config.Deck_Notifications{},
-			Providers:     &config.Deck_Providers{},
 		},
 	},
 }
 
 func TestHalToDeck(t *testing.T) {
-	for _, tt := range deckTests {
+	for _, tt := range deckTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToDeck(tt.hal)
+			got := deckTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/deck_test.go
+++ b/internal/convert/deck_test.go
@@ -36,11 +36,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToDeckTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Deck
-}{
+var deckTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -260,7 +256,7 @@ var halToDeckTests = []struct {
 }
 
 func TestHalToDeck(t *testing.T) {
-	for _, tt := range halToDeckTests {
+	for _, tt := range deckTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToDeck(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/echo_test.go
+++ b/internal/convert/echo_test.go
@@ -29,23 +29,34 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var echoTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Echo{},
-	},
-	{
-		"Empty notifications",
-		&config.Hal{
-			Notifications: &notification.Notifications{},
+var echoTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToEcho(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Echo{},
 		},
-		&config.Echo{},
-	},
-	{
-		"Slack notification",
-		&config.Hal{
-			Notifications: &notification.Notifications{
+		{
+			"Empty notifications",
+			&config.Hal{
+				Notifications: &notification.Notifications{},
+			},
+			&config.Echo{},
+		},
+		{
+			"Slack notification",
+			&config.Hal{
+				Notifications: &notification.Notifications{
+					Slack: &notification.Slack{
+						Enabled: true,
+						BotName: "my-bot",
+						Token:   "my-token",
+						BaseUrl: "https://slack.test/",
+					},
+				},
+			},
+			&config.Echo{
 				Slack: &notification.Slack{
 					Enabled: true,
 					BotName: "my-bot",
@@ -54,106 +65,110 @@ var echoTests = []testCase{
 				},
 			},
 		},
-		&config.Echo{
-			Slack: &notification.Slack{
-				Enabled: true,
-				BotName: "my-bot",
-				Token:   "my-token",
-				BaseUrl: "https://slack.test/",
+		{
+			"Empty pub/sub",
+			&config.Hal{
+				Pubsub: &pubsub.Pubsub{},
+			},
+			&config.Echo{
+				Pubsub: &pubsub.Pubsub{},
 			},
 		},
-	},
-	{
-		"Empty pub/sub",
-		&config.Hal{
-			Pubsub: &pubsub.Pubsub{},
-		},
-		&config.Echo{
-			Pubsub: &pubsub.Pubsub{},
-		},
-	},
-	{
-		"Empty Google pub/sub",
-		&config.Hal{
-			Pubsub: &pubsub.Pubsub{
-				Google: &pubsub.Google{},
+		{
+			"Empty Google pub/sub",
+			&config.Hal{
+				Pubsub: &pubsub.Pubsub{
+					Google: &pubsub.Google{},
+				},
+			},
+			&config.Echo{
+				Pubsub: &pubsub.Pubsub{
+					Google: &pubsub.Google{},
+				},
 			},
 		},
-		&config.Echo{
-			Pubsub: &pubsub.Pubsub{
-				Google: &pubsub.Google{},
-			},
-		},
-	},
-	{
-		"Google pub/sub",
-		&config.Hal{
-			Pubsub: &pubsub.Pubsub{
-				Google: &pubsub.Google{
-					Subscriptions: []*pubsub.GoogleSubscriber{
-						{
-							Name:             "my-account",
-							Project:          "my-project",
-							SubscriptionName: "my-subscription",
-							JsonPath:         "/var/secrets/my-account.json",
-							MessageFormat:    pubsub.MessageFormat_GCS,
+		{
+			"Google pub/sub",
+			&config.Hal{
+				Pubsub: &pubsub.Pubsub{
+					Google: &pubsub.Google{
+						Subscriptions: []*pubsub.GoogleSubscriber{
+							{
+								Name:             "my-account",
+								Project:          "my-project",
+								SubscriptionName: "my-subscription",
+								JsonPath:         "/var/secrets/my-account.json",
+								MessageFormat:    pubsub.MessageFormat_GCS,
+							},
+						},
+						Publishers: []*pubsub.GooglePublisher{
+							{
+								Name:      "my-account",
+								Project:   "my-project",
+								TopicName: "my-topic",
+							},
 						},
 					},
-					Publishers: []*pubsub.GooglePublisher{
-						{
-							Name:      "my-account",
-							Project:   "my-project",
-							TopicName: "my-topic",
+				},
+			},
+			&config.Echo{
+				Pubsub: &pubsub.Pubsub{
+					Google: &pubsub.Google{
+						Subscriptions: []*pubsub.GoogleSubscriber{
+							{
+								Name:             "my-account",
+								Project:          "my-project",
+								SubscriptionName: "my-subscription",
+								JsonPath:         "/var/secrets/my-account.json",
+								MessageFormat:    pubsub.MessageFormat_GCS,
+							},
+						},
+						Publishers: []*pubsub.GooglePublisher{
+							{
+								Name:      "my-account",
+								Project:   "my-project",
+								TopicName: "my-topic",
+							},
 						},
 					},
 				},
 			},
 		},
-		&config.Echo{
-			Pubsub: &pubsub.Pubsub{
-				Google: &pubsub.Google{
-					Subscriptions: []*pubsub.GoogleSubscriber{
-						{
-							Name:             "my-account",
-							Project:          "my-project",
-							SubscriptionName: "my-subscription",
-							JsonPath:         "/var/secrets/my-account.json",
-							MessageFormat:    pubsub.MessageFormat_GCS,
-						},
-					},
-					Publishers: []*pubsub.GooglePublisher{
-						{
-							Name:      "my-account",
-							Project:   "my-project",
-							TopicName: "my-topic",
-						},
-					},
+		{
+			"Empty CI",
+			&config.Hal{
+				Ci: &ci.Ci{},
+			},
+			&config.Echo{},
+		},
+		{
+			"Empty GCB account",
+			&config.Hal{
+				Ci: &ci.Ci{
+					Gcb: &ci.GoogleCloudBuild{},
 				},
 			},
-		},
-	},
-	{
-		"Empty CI",
-		&config.Hal{
-			Ci: &ci.Ci{},
-		},
-		&config.Echo{},
-	},
-	{
-		"Empty GCB account",
-		&config.Hal{
-			Ci: &ci.Ci{
+			&config.Echo{
 				Gcb: &ci.GoogleCloudBuild{},
 			},
 		},
-		&config.Echo{
-			Gcb: &ci.GoogleCloudBuild{},
-		},
-	},
-	{
-		"GCB account",
-		&config.Hal{
-			Ci: &ci.Ci{
+		{
+			"GCB account",
+			&config.Hal{
+				Ci: &ci.Ci{
+					Gcb: &ci.GoogleCloudBuild{
+						Enabled: true,
+						Accounts: []*ci.GoogleCloudBuildAccount{
+							{
+								Name:             "my-account",
+								Project:          "my-project",
+								SubscriptionName: "my-subscription",
+							},
+						},
+					},
+				},
+			},
+			&config.Echo{
 				Gcb: &ci.GoogleCloudBuild{
 					Enabled: true,
 					Accounts: []*ci.GoogleCloudBuildAccount{
@@ -166,55 +181,43 @@ var echoTests = []testCase{
 				},
 			},
 		},
-		&config.Echo{
-			Gcb: &ci.GoogleCloudBuild{
-				Enabled: true,
-				Accounts: []*ci.GoogleCloudBuildAccount{
-					{
-						Name:             "my-account",
-						Project:          "my-project",
-						SubscriptionName: "my-subscription",
-					},
-				},
+		{
+			"Empty stats",
+			&config.Hal{
+				Stats: &client.Stats{},
+			},
+			&config.Echo{
+				Stats: &client.Stats{},
 			},
 		},
-	},
-	{
-		"Empty stats",
-		&config.Hal{
-			Stats: &client.Stats{},
+		{
+			"Stats enabled",
+			&config.Hal{
+				Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: true}},
+			},
+			&config.Echo{
+				Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: true}},
+			},
 		},
-		&config.Echo{
-			Stats: &client.Stats{},
+		{
+			"Stats disabled",
+			&config.Hal{
+				Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: false}},
+			},
+			&config.Echo{
+				Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: false}},
+			},
 		},
-	},
-	{
-		"Stats enabled",
-		&config.Hal{
-			Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: true}},
-		},
-		&config.Echo{
-			Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: true}},
-		},
-	},
-	{
-		"Stats disabled",
-		&config.Hal{
-			Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: false}},
-		},
-		&config.Echo{
-			Stats: &client.Stats{Enabled: &wrappers.BoolValue{Value: false}},
-		},
-	},
-	{
-		"Timezone set",
-		&config.Hal{
-			Timezone: "America/Chicago",
-		},
-		&config.Echo{
-			Scheduler: &config.Echo_Scheduler{
-				Cron: &config.Echo_Scheduler_Cron{
-					Timezone: "America/Chicago",
+		{
+			"Timezone set",
+			&config.Hal{
+				Timezone: "America/Chicago",
+			},
+			&config.Echo{
+				Scheduler: &config.Echo_Scheduler{
+					Cron: &config.Echo_Scheduler_Cron{
+						Timezone: "America/Chicago",
+					},
 				},
 			},
 		},
@@ -222,9 +225,9 @@ var echoTests = []testCase{
 }
 
 func TestHalToEcho(t *testing.T) {
-	for _, tt := range echoTests {
+	for _, tt := range echoTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToEcho(tt.hal)
+			got := echoTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/echo_test.go
+++ b/internal/convert/echo_test.go
@@ -225,12 +225,5 @@ var echoTests = configTest{
 }
 
 func TestHalToEcho(t *testing.T) {
-	for _, tt := range echoTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := echoTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, echoTests)
 }

--- a/internal/convert/echo_test.go
+++ b/internal/convert/echo_test.go
@@ -29,11 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToEchoTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Echo
-}{
+var echoTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -226,7 +222,7 @@ var halToEchoTests = []struct {
 }
 
 func TestHalToEcho(t *testing.T) {
-	for _, tt := range halToEchoTests {
+	for _, tt := range echoTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToEcho(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/fiat_test.go
+++ b/internal/convert/fiat_test.go
@@ -73,12 +73,5 @@ var fiatTests = configTest{
 }
 
 func TestHalToFiat(t *testing.T) {
-	for _, tt := range fiatTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := fiatTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, fiatTests)
 }

--- a/internal/convert/fiat_test.go
+++ b/internal/convert/fiat_test.go
@@ -26,11 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToFiatTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Fiat
-}{
+var fiatTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -74,7 +70,7 @@ var halToFiatTests = []struct {
 }
 
 func TestHalToFiat(t *testing.T) {
-	for _, tt := range halToFiatTests {
+	for _, tt := range fiatTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToFiat(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/front50_test.go
+++ b/internal/convert/front50_test.go
@@ -99,12 +99,5 @@ var front50Tests = configTest{
 }
 
 func TestHalToFront50(t *testing.T) {
-	for _, tt := range front50Tests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := front50Tests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, front50Tests)
 }

--- a/internal/convert/front50_test.go
+++ b/internal/convert/front50_test.go
@@ -26,69 +26,72 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var front50Tests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Front50{
-			Spinnaker: &config.Front50_Spinnaker{},
-		},
-	},
-	{
-		"Empty persistent storage",
-		&config.Hal{
-			PersistentStorage: &storage.PersistentStorage{},
-		},
-		&config.Front50{
-			Spinnaker: &config.Front50_Spinnaker{},
-		},
-	},
-	{
-		"Empty persistent storage configs",
-		&config.Hal{
-			PersistentStorage: &storage.PersistentStorage{
-				Gcs: &storage.Gcs{},
-				S3:  &storage.S3{},
+var front50Tests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToFront50(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Front50{
+				Spinnaker: &config.Front50_Spinnaker{},
 			},
 		},
-		&config.Front50{
-			Spinnaker: &config.Front50_Spinnaker{
-				Gcs: &storage.Gcs{},
-				S3:  &storage.S3{},
+		{
+			"Empty persistent storage",
+			&config.Hal{
+				PersistentStorage: &storage.PersistentStorage{},
+			},
+			&config.Front50{
+				Spinnaker: &config.Front50_Spinnaker{},
 			},
 		},
-	},
-	{
-		"GCS and S3 storage configured",
-		&config.Hal{
-			PersistentStorage: &storage.PersistentStorage{
-				Gcs: &storage.Gcs{
-					Enabled:  true,
-					JsonPath: "/var/secrets/my-gcs-key.json",
-					Project:  "my-project",
-					Bucket:   "my-gcs-bucket",
+		{
+			"Empty persistent storage configs",
+			&config.Hal{
+				PersistentStorage: &storage.PersistentStorage{
+					Gcs: &storage.Gcs{},
+					S3:  &storage.S3{},
 				},
-				S3: &storage.S3{
-					Enabled:              false,
-					Bucket:               "my-s3-bucket",
-					PathStyleAccess:      &wrappers.BoolValue{Value: true},
-					ServerSideEncryption: storage.S3ServerSideEncryption_AES256,
+			},
+			&config.Front50{
+				Spinnaker: &config.Front50_Spinnaker{
+					Gcs: &storage.Gcs{},
+					S3:  &storage.S3{},
 				},
 			},
 		},
-		&config.Front50{
-			Spinnaker: &config.Front50_Spinnaker{
-				Gcs: &storage.Gcs{
-					Enabled:  true,
-					JsonPath: "/var/secrets/my-gcs-key.json",
-					Project:  "my-project",
-					Bucket:   "my-gcs-bucket",
+		{
+			"GCS and S3 storage configured",
+			&config.Hal{
+				PersistentStorage: &storage.PersistentStorage{
+					Gcs: &storage.Gcs{
+						Enabled:  true,
+						JsonPath: "/var/secrets/my-gcs-key.json",
+						Project:  "my-project",
+						Bucket:   "my-gcs-bucket",
+					},
+					S3: &storage.S3{
+						Enabled:              false,
+						Bucket:               "my-s3-bucket",
+						PathStyleAccess:      &wrappers.BoolValue{Value: true},
+						ServerSideEncryption: storage.S3ServerSideEncryption_AES256,
+					},
 				},
-				S3: &storage.S3{
-					Enabled:              false,
-					Bucket:               "my-s3-bucket",
-					PathStyleAccess:      &wrappers.BoolValue{Value: true},
-					ServerSideEncryption: storage.S3ServerSideEncryption_AES256,
+			},
+			&config.Front50{
+				Spinnaker: &config.Front50_Spinnaker{
+					Gcs: &storage.Gcs{
+						Enabled:  true,
+						JsonPath: "/var/secrets/my-gcs-key.json",
+						Project:  "my-project",
+						Bucket:   "my-gcs-bucket",
+					},
+					S3: &storage.S3{
+						Enabled:              false,
+						Bucket:               "my-s3-bucket",
+						PathStyleAccess:      &wrappers.BoolValue{Value: true},
+						ServerSideEncryption: storage.S3ServerSideEncryption_AES256,
+					},
 				},
 			},
 		},
@@ -96,9 +99,9 @@ var front50Tests = []testCase{
 }
 
 func TestHalToFront50(t *testing.T) {
-	for _, tt := range front50Tests {
+	for _, tt := range front50Tests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToFront50(tt.hal)
+			got := front50Tests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/front50_test.go
+++ b/internal/convert/front50_test.go
@@ -26,11 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToFront50Tests = []struct {
-	n    string
-	h    *config.Hal
-	want *config.Front50
-}{
+var front50Tests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -100,9 +96,9 @@ var halToFront50Tests = []struct {
 }
 
 func TestHalToFront50(t *testing.T) {
-	for _, tt := range halToFront50Tests {
-		t.Run(tt.n, func(t *testing.T) {
-			got := convert.HalToFront50(tt.h)
+	for _, tt := range front50Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convert.HalToFront50(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/gate_test.go
+++ b/internal/convert/gate_test.go
@@ -30,11 +30,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToGateTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Gate
-}{
+var gateTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -286,7 +282,7 @@ var halToGateTests = []struct {
 }
 
 func TestHalToGate(t *testing.T) {
-	for _, tt := range halToGateTests {
+	for _, tt := range gateTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToGate(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/gate_test.go
+++ b/internal/convert/gate_test.go
@@ -30,17 +30,31 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var gateTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Gate{},
-	},
-	{
-		"Server SSL config",
-		&config.Hal{
-			Security: &security.Security{
-				ApiSecurity: &security.ApiSecurity{
+var gateTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToGate(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Gate{},
+		},
+		{
+			"Server SSL config",
+			&config.Hal{
+				Security: &security.Security{
+					ApiSecurity: &security.ApiSecurity{
+						Ssl: &security.ApiSsl{
+							Enabled:      true,
+							KeyAlias:     "alias",
+							KeyStore:     "/var/secrets/keystore.jks",
+							KeyStoreType: "jks",
+							ClientAuth:   security.ClientAuth_WANT,
+						},
+					},
+				},
+			},
+			&config.Gate{
+				Server: &config.ServerConfig{
 					Ssl: &security.ApiSsl{
 						Enabled:      true,
 						KeyAlias:     "alias",
@@ -51,38 +65,38 @@ var gateTests = []testCase{
 				},
 			},
 		},
-		&config.Gate{
-			Server: &config.ServerConfig{
-				Ssl: &security.ApiSsl{
-					Enabled:      true,
-					KeyAlias:     "alias",
-					KeyStore:     "/var/secrets/keystore.jks",
-					KeyStoreType: "jks",
-					ClientAuth:   security.ClientAuth_WANT,
+		{
+			"CORS config",
+			&config.Hal{
+				Security: &security.Security{
+					ApiSecurity: &security.ApiSecurity{
+						CorsAccessPattern: "https://spinnaker.test/",
+					},
+				},
+			},
+			&config.Gate{
+				Cors: &config.Cors{
+					AllowedOriginsPattern: "https://spinnaker.test/",
 				},
 			},
 		},
-	},
-	{
-		"CORS config",
-		&config.Hal{
-			Security: &security.Security{
-				ApiSecurity: &security.ApiSecurity{
-					CorsAccessPattern: "https://spinnaker.test/",
+		{
+			"Basic auth",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Basic: &authn.Basic{
+							Enabled: true,
+							User: &authn.UsernamePassword{
+								Username: "user",
+								Password: "passw0rd",
+							},
+						},
+					},
 				},
 			},
-		},
-		&config.Gate{
-			Cors: &config.Cors{
-				AllowedOriginsPattern: "https://spinnaker.test/",
-			},
-		},
-	},
-	{
-		"Basic auth",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
+			&config.Gate{
+				Security: &config.SpringSecurity{
 					Basic: &authn.Basic{
 						Enabled: true,
 						User: &authn.UsernamePassword{
@@ -93,23 +107,24 @@ var gateTests = []testCase{
 				},
 			},
 		},
-		&config.Gate{
-			Security: &config.SpringSecurity{
-				Basic: &authn.Basic{
-					Enabled: true,
-					User: &authn.UsernamePassword{
-						Username: "user",
-						Password: "passw0rd",
+		{
+			"Oauth2 enabled",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Oauth2: &authn.OAuth2{
+							Enabled: true,
+							Client: &authn.OAuth2Client{
+								ClientId:     "my-client",
+								ClientSecret: "my-secret",
+							},
+							Provider: authn.OAuth2_GITHUB,
+						},
 					},
 				},
 			},
-		},
-	},
-	{
-		"Oauth2 enabled",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
+			&config.Gate{
+				Security: &config.SpringSecurity{
 					Oauth2: &authn.OAuth2{
 						Enabled: true,
 						Client: &authn.OAuth2Client{
@@ -121,103 +136,100 @@ var gateTests = []testCase{
 				},
 			},
 		},
-		&config.Gate{
-			Security: &config.SpringSecurity{
-				Oauth2: &authn.OAuth2{
-					Enabled: true,
-					Client: &authn.OAuth2Client{
-						ClientId:     "my-client",
-						ClientSecret: "my-secret",
-					},
-					Provider: authn.OAuth2_GITHUB,
-				},
-			},
-		},
-	},
-	{
-		// Because Gate does not look at the enabled field for Oauth2 and instead
-		// enables Oauth2 any time there is a client id set, we should not write out
-		// the config if it is disabled. We can change this and remove the test if
-		// we update gate to look at the enabled flag.
-		"Oauth2 disabled",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
-					Oauth2: &authn.OAuth2{
-						Enabled: false,
-						Client: &authn.OAuth2Client{
-							ClientId:     "my-client",
-							ClientSecret: "my-secret",
+		{
+			// Because Gate does not look at the enabled field for Oauth2 and instead
+			// enables Oauth2 any time there is a client id set, we should not write out
+			// the config if it is disabled. We can change this and remove the test if
+			// we update gate to look at the enabled flag.
+			"Oauth2 disabled",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Oauth2: &authn.OAuth2{
+							Enabled: false,
+							Client: &authn.OAuth2Client{
+								ClientId:     "my-client",
+								ClientSecret: "my-secret",
+							},
+							Provider: authn.OAuth2_GITHUB,
 						},
-						Provider: authn.OAuth2_GITHUB,
 					},
 				},
 			},
+			&config.Gate{},
 		},
-		&config.Gate{},
-	},
-	{
-		"SAML",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
-					Saml: &authn.Saml{
-						Enabled:     true,
-						MetadataUrl: "https://my-saml-provider.test/",
+		{
+			"SAML",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Saml: &authn.Saml{
+							Enabled:     true,
+							MetadataUrl: "https://my-saml-provider.test/",
+						},
 					},
 				},
 			},
-		},
-		&config.Gate{
-			Saml: &authn.Saml{
-				Enabled:     true,
-				MetadataUrl: "https://my-saml-provider.test/",
-			},
-		},
-	},
-	{
-		"LDAP",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
-					Ldap: &authn.Ldap{
-						Enabled: true,
-						Url:     "https://my-ldap-provider.test",
-					},
+			&config.Gate{
+				Saml: &authn.Saml{
+					Enabled:     true,
+					MetadataUrl: "https://my-saml-provider.test/",
 				},
 			},
 		},
-		&config.Gate{
-			Ldap: &authn.Ldap{
-				Enabled: true,
-				Url:     "https://my-ldap-provider.test",
-			},
-		},
-	},
-	{
-		"X509",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
-					X509: &authn.X509{
-						Enabled: true,
-						RoleOid: "abc",
+		{
+			"LDAP",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Ldap: &authn.Ldap{
+							Enabled: true,
+							Url:     "https://my-ldap-provider.test",
+						},
 					},
 				},
 			},
-		},
-		&config.Gate{
-			X509: &authn.X509{
-				Enabled: true,
-				RoleOid: "abc",
+			&config.Gate{
+				Ldap: &authn.Ldap{
+					Enabled: true,
+					Url:     "https://my-ldap-provider.test",
+				},
 			},
 		},
-	},
-	{
-		"IAP",
-		&config.Hal{
-			Security: &security.Security{
-				Authn: &authn.Authentication{
+		{
+			"X509",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						X509: &authn.X509{
+							Enabled: true,
+							RoleOid: "abc",
+						},
+					},
+				},
+			},
+			&config.Gate{
+				X509: &authn.X509{
+					Enabled: true,
+					RoleOid: "abc",
+				},
+			},
+		},
+		{
+			"IAP",
+			&config.Hal{
+				Security: &security.Security{
+					Authn: &authn.Authentication{
+						Iap: &authn.Iap{
+							Enabled:   true,
+							JwtHeader: "my-header",
+							IssuerId:  "abc",
+						},
+					},
+				},
+			},
+			&config.Gate{
+				Google: &config.Gate_GoogleConfig{
 					Iap: &authn.Iap{
 						Enabled:   true,
 						JwtHeader: "my-header",
@@ -226,65 +238,56 @@ var gateTests = []testCase{
 				},
 			},
 		},
-		&config.Gate{
-			Google: &config.Gate_GoogleConfig{
-				Iap: &authn.Iap{
-					Enabled:   true,
-					JwtHeader: "my-header",
-					IssuerId:  "abc",
-				},
-			},
-		},
-	},
-	{
-		"Canary enabled",
-		&config.Hal{
-			Canary: &canary.Canary{
-				Enabled: true,
-			},
-		},
-		&config.Gate{
-			Services: &config.Gate_Services{
-				Kayenta: &config.ServiceSettings{
+		{
+			"Canary enabled",
+			&config.Hal{
+				Canary: &canary.Canary{
 					Enabled: true,
 				},
 			},
-		},
-	},
-	{
-		"Deck base URL",
-		&config.Hal{
-			Security: &security.Security{
-				UiSecurity: &security.UiSecurity{
-					OverrideBaseUrl: "https://spinnaker.test:9000",
+			&config.Gate{
+				Services: &config.Gate_Services{
+					Kayenta: &config.ServiceSettings{
+						Enabled: true,
+					},
 				},
 			},
 		},
-		&config.Gate{
-			Services: &config.Gate_Services{
-				Deck: &config.ServiceSettings{
-					BaseUrl: "https://spinnaker.test:9000",
+		{
+			"Deck base URL",
+			&config.Hal{
+				Security: &security.Security{
+					UiSecurity: &security.UiSecurity{
+						OverrideBaseUrl: "https://spinnaker.test:9000",
+					},
+				},
+			},
+			&config.Gate{
+				Services: &config.Gate_Services{
+					Deck: &config.ServiceSettings{
+						BaseUrl: "https://spinnaker.test:9000",
+					},
 				},
 			},
 		},
-	},
-	{
-		"Gremlin enabled",
-		&config.Hal{
-			Features: &client.Features{Gremlin: true},
-		},
-		&config.Gate{
-			Integrations: &config.Gate_Integrations{
-				Gremlin: &config.Gate_Integrations_Gremlin{Enabled: true},
+		{
+			"Gremlin enabled",
+			&config.Hal{
+				Features: &client.Features{Gremlin: true},
+			},
+			&config.Gate{
+				Integrations: &config.Gate_Integrations{
+					Gremlin: &config.Gate_Integrations_Gremlin{Enabled: true},
+				},
 			},
 		},
 	},
 }
 
 func TestHalToGate(t *testing.T) {
-	for _, tt := range gateTests {
+	for _, tt := range gateTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToGate(tt.hal)
+			got := gateTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/gate_test.go
+++ b/internal/convert/gate_test.go
@@ -285,12 +285,5 @@ var gateTests = configTest{
 }
 
 func TestHalToGate(t *testing.T) {
-	for _, tt := range gateTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := gateTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, gateTests)
 }

--- a/internal/convert/igor_test.go
+++ b/internal/convert/igor_test.go
@@ -158,12 +158,5 @@ var igorTests = configTest{
 }
 
 func TestHalToIgor(t *testing.T) {
-	for _, tt := range igorTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := igorTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, igorTests)
 }

--- a/internal/convert/igor_test.go
+++ b/internal/convert/igor_test.go
@@ -32,11 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToIgorTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Igor
-}{
+var igorTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -159,7 +155,7 @@ var halToIgorTests = []struct {
 }
 
 func TestHalToIgor(t *testing.T) {
-	for _, tt := range halToIgorTests {
+	for _, tt := range igorTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToIgor(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/kayenta_test.go
+++ b/internal/convert/kayenta_test.go
@@ -26,11 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToKayentaTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Kayenta
-}{
+var kayentaTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -340,7 +336,7 @@ var halToKayentaTests = []struct {
 }
 
 func TestHalToKayenta(t *testing.T) {
-	for _, tt := range halToKayentaTests {
+	for _, tt := range kayentaTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToKayenta(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/kayenta_test.go
+++ b/internal/convert/kayenta_test.go
@@ -339,12 +339,5 @@ var kayentaTests = configTest{
 }
 
 func TestHalToKayenta(t *testing.T) {
-	for _, tt := range kayentaTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := kayentaTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, kayentaTests)
 }

--- a/internal/convert/orca_test.go
+++ b/internal/convert/orca_test.go
@@ -29,105 +29,108 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var orcaTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Orca{},
-	},
-	{
-		"AWS disabled",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
-				Aws: &cloudprovider.Aws{
-					Enabled:        false,
-					PrimaryAccount: "my-account",
+var orcaTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToOrca(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Orca{},
+		},
+		{
+			"AWS disabled",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Aws: &cloudprovider.Aws{
+						Enabled:        false,
+						PrimaryAccount: "my-account",
+					},
+				},
+			},
+			&config.Orca{},
+		},
+		{
+			"AWS enabled",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Aws: &cloudprovider.Aws{
+						Enabled:        true,
+						PrimaryAccount: "my-account",
+					},
+				},
+			},
+			&config.Orca{
+				Default: &config.Orca_Defaults{
+					Bake: &config.Orca_Defaults_BakeDefaults{
+						Account: "my-account",
+					},
 				},
 			},
 		},
-		&config.Orca{},
-	},
-	{
-		"AWS enabled",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
-				Aws: &cloudprovider.Aws{
-					Enabled:        true,
-					PrimaryAccount: "my-account",
+		{
+			// TODO: This should probably explicitly set templates to disabled rather
+			// than return an empty config.
+			"Pipeline templates disabled",
+			&config.Hal{
+				Features: &client.Features{PipelineTemplates: false},
+			},
+			&config.Orca{},
+		},
+		{
+			"Pipeline templates enabled",
+			&config.Hal{
+				Features: &client.Features{PipelineTemplates: true},
+			},
+			&config.Orca{
+				PipelineTemplates: &config.Orca_PipelineTemplates{Enabled: true},
+			},
+		},
+		{
+			"Webhook trust configured",
+			&config.Hal{
+				Webhook: &security.WebhookConfig{
+					Trust: &security.TrustStore{
+						Enabled:            true,
+						TrustStore:         "/var/secrets/store.jks",
+						TrustStorePassword: "passw0rd",
+					},
+				},
+			},
+			&config.Orca{
+				Webhook: &security.WebhookConfig{
+					Trust: &security.TrustStore{
+						Enabled:            true,
+						TrustStore:         "/var/secrets/store.jks",
+						TrustStorePassword: "passw0rd",
+					},
 				},
 			},
 		},
-		&config.Orca{
-			Default: &config.Orca_Defaults{
-				Bake: &config.Orca_Defaults_BakeDefaults{
-					Account: "my-account",
-				},
-			},
-		},
-	},
-	{
-		// TODO: This should probably explicitly set templates to disabled rather
-		// than return an empty config.
-		"Pipeline templates disabled",
-		&config.Hal{
-			Features: &client.Features{PipelineTemplates: false},
-		},
-		&config.Orca{},
-	},
-	{
-		"Pipeline templates enabled",
-		&config.Hal{
-			Features: &client.Features{PipelineTemplates: true},
-		},
-		&config.Orca{
-			PipelineTemplates: &config.Orca_PipelineTemplates{Enabled: true},
-		},
-	},
-	{
-		"Webhook trust configured",
-		&config.Hal{
-			Webhook: &security.WebhookConfig{
-				Trust: &security.TrustStore{
-					Enabled:            true,
-					TrustStore:         "/var/secrets/store.jks",
-					TrustStorePassword: "passw0rd",
-				},
-			},
-		},
-		&config.Orca{
-			Webhook: &security.WebhookConfig{
-				Trust: &security.TrustStore{
-					Enabled:            true,
-					TrustStore:         "/var/secrets/store.jks",
-					TrustStorePassword: "passw0rd",
-				},
-			},
-		},
-	},
-	{
-		"Canary enabled",
-		&config.Hal{
-			Canary: &canary.Canary{
-				Enabled: true,
-			},
-		},
-		&config.Orca{
-			Services: &config.Orca_Services{
-				Kayenta: &config.ServiceSettings{
+		{
+			"Canary enabled",
+			&config.Hal{
+				Canary: &canary.Canary{
 					Enabled: true,
 				},
 			},
+			&config.Orca{
+				Services: &config.Orca_Services{
+					Kayenta: &config.ServiceSettings{
+						Enabled: true,
+					},
+				},
+			},
 		},
-	},
-	{
-		"Timezone set",
-		&config.Hal{
-			Timezone: "America/Chicago",
-		},
-		&config.Orca{
-			Tasks: &config.Orca_Tasks{
-				ExecutionWindow: &config.Orca_Tasks_ExecutionWindow{
-					Timezone: "America/Chicago",
+		{
+			"Timezone set",
+			&config.Hal{
+				Timezone: "America/Chicago",
+			},
+			&config.Orca{
+				Tasks: &config.Orca_Tasks{
+					ExecutionWindow: &config.Orca_Tasks_ExecutionWindow{
+						Timezone: "America/Chicago",
+					},
 				},
 			},
 		},
@@ -135,9 +138,9 @@ var orcaTests = []testCase{
 }
 
 func TestHalToOrca(t *testing.T) {
-	for _, tt := range orcaTests {
+	for _, tt := range orcaTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToOrca(tt.hal)
+			got := orcaTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/orca_test.go
+++ b/internal/convert/orca_test.go
@@ -138,12 +138,5 @@ var orcaTests = configTest{
 }
 
 func TestHalToOrca(t *testing.T) {
-	for _, tt := range orcaTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := orcaTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, orcaTests)
 }

--- a/internal/convert/orca_test.go
+++ b/internal/convert/orca_test.go
@@ -29,11 +29,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToOrcaTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Orca
-}{
+var orcaTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -139,7 +135,7 @@ var halToOrcaTests = []struct {
 }
 
 func TestHalToOrca(t *testing.T) {
-	for _, tt := range halToOrcaTests {
+	for _, tt := range orcaTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToOrca(tt.hal)
 			if !proto.Equal(got, tt.want) {

--- a/internal/convert/rosco_test.go
+++ b/internal/convert/rosco_test.go
@@ -137,12 +137,5 @@ var roscoTests = configTest{
 }
 
 func TestHalToRosco(t *testing.T) {
-	for _, tt := range roscoTests.tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := roscoTests.generator(tt.hal)
-			if !proto.Equal(got, tt.want) {
-				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
-			}
-		})
-	}
+	runConfigTest(t, roscoTests)
 }

--- a/internal/convert/rosco_test.go
+++ b/internal/convert/rosco_test.go
@@ -25,53 +25,85 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var roscoTests = []testCase{
-	{
-		"Empty hal config",
-		&config.Hal{},
-		&config.Rosco{},
-	},
-	{
-		"Empty providers",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{},
+var roscoTests = configTest{
+	generator: func(h *config.Hal) proto.Message { return convert.HalToRosco(h) },
+	tests: []testCase{
+		{
+			"Empty hal config",
+			&config.Hal{},
+			&config.Rosco{},
 		},
-		&config.Rosco{},
-	},
-	{
-		"Empty Google provider",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
+		{
+			"Empty providers",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{},
+			},
+			&config.Rosco{},
+		},
+		{
+			"Empty Google provider",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Google: &cloudprovider.GoogleComputeEngine{},
+				},
+			},
+			&config.Rosco{
 				Google: &cloudprovider.GoogleComputeEngine{},
 			},
 		},
-		&config.Rosco{
-			Google: &cloudprovider.GoogleComputeEngine{},
-		},
-	},
-	{
-		"Kubernetes account",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
-				Kubernetes: &cloudprovider.Kubernetes{
-					Enabled: true,
-					Accounts: []*cloudprovider.KubernetesAccount{
-						{
-							Name:           "my-account",
-							Kinds:          []string{"deployment"},
-							OmitNamespaces: []string{"kube-system"},
+		{
+			"Kubernetes account",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Kubernetes: &cloudprovider.Kubernetes{
+						Enabled: true,
+						Accounts: []*cloudprovider.KubernetesAccount{
+							{
+								Name:           "my-account",
+								Kinds:          []string{"deployment"},
+								OmitNamespaces: []string{"kube-system"},
+							},
 						},
+						PrimaryAccount: "my-account",
 					},
-					PrimaryAccount: "my-account",
 				},
 			},
+			&config.Rosco{},
 		},
-		&config.Rosco{},
-	},
-	{
-		"AWS account",
-		&config.Hal{
-			Providers: &cloudprovider.Providers{
+		{
+			"AWS account",
+			&config.Hal{
+				Providers: &cloudprovider.Providers{
+					Aws: &cloudprovider.Aws{
+						Enabled: true,
+						Accounts: []*cloudprovider.AwsAccount{
+							{
+								Name: "my-account",
+							},
+						},
+						BakeryDefaults: &cloudprovider.AwsBakeryDefaults{
+							AwsAccessKey:                "my-key",
+							AwsSecretKey:                "my-secret-key",
+							AwsAssociatePublicIpAddress: false,
+							BaseImages: []*cloudprovider.AwsBaseImageSettings{
+								{
+									BaseImage: &cloudprovider.AwsBaseImage{
+										Id:               "my-image",
+										ShortDescription: "this is an image",
+									},
+									VirtualizationSettings: &cloudprovider.AwsVirtualizationSettings{
+										Region:             "us-east-1",
+										VirtualizationType: "hvm",
+										InstanceType:       "t2-micro",
+									},
+								},
+							},
+						},
+						PrimaryAccount: "my-account",
+					},
+				},
+			},
+			&config.Rosco{
 				Aws: &cloudprovider.Aws{
 					Enabled: true,
 					Accounts: []*cloudprovider.AwsAccount{
@@ -101,42 +133,13 @@ var roscoTests = []testCase{
 				},
 			},
 		},
-		&config.Rosco{
-			Aws: &cloudprovider.Aws{
-				Enabled: true,
-				Accounts: []*cloudprovider.AwsAccount{
-					{
-						Name: "my-account",
-					},
-				},
-				BakeryDefaults: &cloudprovider.AwsBakeryDefaults{
-					AwsAccessKey:                "my-key",
-					AwsSecretKey:                "my-secret-key",
-					AwsAssociatePublicIpAddress: false,
-					BaseImages: []*cloudprovider.AwsBaseImageSettings{
-						{
-							BaseImage: &cloudprovider.AwsBaseImage{
-								Id:               "my-image",
-								ShortDescription: "this is an image",
-							},
-							VirtualizationSettings: &cloudprovider.AwsVirtualizationSettings{
-								Region:             "us-east-1",
-								VirtualizationType: "hvm",
-								InstanceType:       "t2-micro",
-							},
-						},
-					},
-				},
-				PrimaryAccount: "my-account",
-			},
-		},
 	},
 }
 
 func TestHalToRosco(t *testing.T) {
-	for _, tt := range roscoTests {
+	for _, tt := range roscoTests.tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert.HalToRosco(tt.hal)
+			got := roscoTests.generator(tt.hal)
 			if !proto.Equal(got, tt.want) {
 				t.Errorf("Expected hal config to generate %v, got %v", tt.want, got)
 			}

--- a/internal/convert/rosco_test.go
+++ b/internal/convert/rosco_test.go
@@ -25,11 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var halToRoscoTests = []struct {
-	name string
-	hal  *config.Hal
-	want *config.Rosco
-}{
+var roscoTests = []testCase{
 	{
 		"Empty hal config",
 		&config.Hal{},
@@ -138,7 +134,7 @@ var halToRoscoTests = []struct {
 }
 
 func TestHalToRosco(t *testing.T) {
-	for _, tt := range halToRoscoTests {
+	for _, tt := range roscoTests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convert.HalToRosco(tt.hal)
 			if !proto.Equal(got, tt.want) {


### PR DESCRIPTION
* test(core): Create named type for test cases

  All of the config generation tests define the same struct of test cases inline; let's just give it a name and re-use it across the tests to reduce duplication.

  Also remove halTo... from the variables holding the test cases for brevity.

* test(core): Add configTest type

  This type wraps a config generator and a slice of tests that test that generator.

  Update each of the tests to specify the generator and the actual tests. As this changes the indentation of all the tests, this commit will look much cleaner ignoring whitespace.

* test(core): Pull common test logic to a function

  All the config generator tests do the exact same thing to a configTest stuct; pull this logic into a helper function so it's not repeated in every test file.

* test(core): Improve debuggability of unit tests

  If we find that two config protos are not equal, print a diff of them instead of the full contents of both protos.