### PR TITLE
style(core): Fix remaining lint errors

### DIFF
--- a/cmd/kleat/main.go
+++ b/cmd/kleat/main.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package main
 
 import (

--- a/cmd/kleat/main.go
+++ b/cmd/kleat/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	if len(os.Args) != 3 {
-		fmt.Fprintf(os.Stderr, "arguments must be <halPath> <dir>\n")
+		_, _ = fmt.Fprint(os.Stderr, "arguments must be <halPath> <dir>\n")
 		os.Exit(1)
 	}
 

--- a/internal/convert/deck.go
+++ b/internal/convert/deck.go
@@ -65,7 +65,7 @@ func getDeckCanaryConfig(h *config.Hal) *config.Deck_Canary {
 }
 
 // TODO: Actually get changelog config
-func getDeckChangelogConfig(h *config.Hal) *config.Deck_Changelog {
+func getDeckChangelogConfig(_ *config.Hal) *config.Deck_Changelog {
 	return nil
 	//return &config.Deck_Changelog{
 	//	FileName: "",

--- a/internal/fileio/fileio.go
+++ b/internal/fileio/fileio.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/spinnaker/kleat/api/client/config"
 	"github.com/spinnaker/kleat/internal/protoyaml"
+	"github.com/spinnaker/kleat/internal/validate"
 	"github.com/spinnaker/kleat/pkg/transform"
-	"github.com/spinnaker/kleat/pkg/validate"
 )
 
 // ParseHalConfig reads the YAML file at halPath parses it into a *config.Hal.
@@ -44,7 +44,7 @@ func ParseHalConfig(halPath string) (*config.Hal, error) {
 		return nil, err
 	}
 
-	if err := validate.ValidateHalConfig(hal); err != nil {
+	if err := validate.HalConfig(hal); err != nil {
 		return nil, err
 	}
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -22,19 +22,19 @@ import (
 	"github.com/spinnaker/kleat/api/client/config"
 )
 
-type ValidationFailure struct {
+type validationFailure struct {
 	msg string
 }
 
-type HalConfigValidator func(*config.Hal) []ValidationFailure
+type halConfigValidator func(*config.Hal) []validationFailure
 
-func getValidators() []HalConfigValidator {
-	return []HalConfigValidator{
+func getValidators() []halConfigValidator {
+	return []halConfigValidator{
 		validateKindsAndOmitKinds,
 	}
 }
 
-func ValidateHalConfig(h *config.Hal) error {
+func HalConfig(h *config.Hal) error {
 	messages := getValidationMessages(h, getValidators())
 	if len(messages) > 0 {
 		msg := strings.Join(messages, "\n")
@@ -43,7 +43,7 @@ func ValidateHalConfig(h *config.Hal) error {
 	return nil
 }
 
-func getValidationMessages(h *config.Hal, fa []HalConfigValidator) []string {
+func getValidationMessages(h *config.Hal, fa []halConfigValidator) []string {
 	var messages []string
 	for _, f := range fa {
 		rs := f(h)
@@ -54,8 +54,8 @@ func getValidationMessages(h *config.Hal, fa []HalConfigValidator) []string {
 	return messages
 }
 
-func validateKindsAndOmitKinds(h *config.Hal) []ValidationFailure {
-	var messages []ValidationFailure
+func validateKindsAndOmitKinds(h *config.Hal) []validationFailure {
+	var messages []validationFailure
 	for _, a := range h.GetProviders().GetKubernetes().GetAccounts() {
 		if !(len(a.GetKinds()) == 0) && !(len(a.GetOmitKinds()) == 0) {
 			messages = append(messages, fatalResult("Cannot specify both kinds and omitKinds."))
@@ -64,8 +64,8 @@ func validateKindsAndOmitKinds(h *config.Hal) []ValidationFailure {
 	return messages
 }
 
-func fatalResult(msg string) ValidationFailure {
-	return ValidationFailure{
+func fatalResult(msg string) validationFailure {
+	return validationFailure{
 		msg: msg,
 	}
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package validate supports validating a *config.Hal and reporting any
+// validation failures.
 package validate
 
 import (
@@ -34,6 +37,7 @@ func getValidators() []halConfigValidator {
 	}
 }
 
+// HalConfig validates the supplied *config.Hal, returning any errors encountered.
 func HalConfig(h *config.Hal) error {
 	messages := getValidationMessages(h, getValidators())
 	if len(messages) > 0 {

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -20,12 +20,12 @@ import (
 
 	"github.com/spinnaker/kleat/api/client/cloudprovider"
 	"github.com/spinnaker/kleat/api/client/config"
-	"github.com/spinnaker/kleat/pkg/validate"
+	"github.com/spinnaker/kleat/internal/validate"
 )
 
 func TestEmptyHalConfig(t *testing.T) {
 	h := &config.Hal{}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -35,7 +35,7 @@ func TestEmptyProviders(t *testing.T) {
 	h := &config.Hal{
 		Providers: &cloudprovider.Providers{},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -47,7 +47,7 @@ func TestEmptyKubernetes(t *testing.T) {
 			Kubernetes: &cloudprovider.Kubernetes{},
 		},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -62,7 +62,7 @@ func TestNoKubernetesAccounts(t *testing.T) {
 			},
 		},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -81,7 +81,7 @@ func TestKuberntesAccountWithNoOmitKinds(t *testing.T) {
 			},
 		},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -101,7 +101,7 @@ func TestKuberntesAccountWithEmptyOmitKinds(t *testing.T) {
 			},
 		},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err != nil {
 		t.Errorf("Expected no validation failures, got %s", err)
 	}
@@ -121,7 +121,7 @@ func TestInvalidKubernetesAccount(t *testing.T) {
 			},
 		},
 	}
-	err := validate.ValidateHalConfig(h)
+	err := validate.HalConfig(h)
 	if err == nil {
 		t.Error("Expected a validation failure, got none")
 	}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Package transform supports transforming between various formats of Spinnaker
+// configuration.
 package transform
 
 import (
@@ -22,6 +25,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// HalToServiceConfigs returns the microservice configurations corresponding
+// to a supplied *config.Hal.
 func HalToServiceConfigs(h *config.Hal) *config.Services {
 	return &config.Services{
 		Clouddriver: convert.HalToClouddriver(h),
@@ -38,6 +43,8 @@ func HalToServiceConfigs(h *config.Hal) *config.Services {
 	}
 }
 
+// GenerateConfigFiles generates the config files corresponding to a supplied
+// *config.Services.
 func GenerateConfigFiles(s *config.Services) (*config.ConfigFiles, error) {
 	var files = []struct {
 		fileName   string

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -144,8 +144,8 @@ func TestHalToServiceYAML(t *testing.T) {
 				t.Fatal(err)
 			}
 			if !bytes.Equal(got, want) {
-				diff := diff.Diff(string(got), string(want))
-				t.Errorf("Generated %s differs from expected:\n%s", tt.file, diff)
+				d := diff.Diff(string(got), string(want))
+				t.Errorf("Generated %s differs from expected:\n%s", tt.file, d)
 			}
 		})
 	}


### PR DESCRIPTION
* refactor(core): Move validate package to internal

  As we deferred any anything except our proof-of-concept validation, this is definitely something we should keep as an implementation detail until we've thought more about it. (We potentially should even delete it as it's a bit strange that we're only validating one field, but at least let's make it internal.)

  Also fix the lint failure, which doesn't like repetition in package/function names (validate.ValidateHalConfig).

  Finally change some names to lowercase so they aren't exported as they aren't used outside the package.

* style(core): Add documentation to fix lint errors

  Add documentation to exported members, fixing the last lint errors in kleat.

* style(core): Fix inspections

  I ran the IntelliJ inspections, and it found three issues, which I fixed since I'm on a roll with minor cleanup. They are:
  * Explicitly assign the result of fmt.Printf to _ to indicate that we are ignoring the error (as there's not much point handling it right before os.Exit anyway). Also use Printf instead of Fprintf as we aren't formatting
  * Rename 'diff' variable which collides with package name
  * Change unused 'h' to _ in function signature (though obviously this will need to be updated when the TODO is handled).