### PR TITLE
feat(release): add release automation configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Kleat Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    if: startsWith(github.repository, 'spinnaker/')
+    runs-on: ubuntu-latest
+    steps:
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Create release
+        uses: goreleaser/goreleaser-action@v2
+          with:
+            args: release --rm-dist
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,2 @@
-before:
-  hooks:
-    - go mod tidy
-
 builds:
 - main: ./cmd/kleat/main.go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,6 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+- main: ./cmd/kleat/main.go

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ replace Halyard. Please see the
 [RFC](https://github.com/spinnaker/governance/blob/master/rfc/halyard-lite.md)
 for an overview of what this tool will do.
 
-It is currently under active development and is not ready for production (or
-even development) use, but stay tuned for updates!
+It is currently under active development, but is ready for early adopters
+to try in development clusters! Please share any feedback in the #kleat
+channel in [Spinnaker slack](join.spinnaker.io).
 
 ### Migrating from Halyard
 


### PR DESCRIPTION
* feat(release): add initial configuration for release with GoReleaser and GitHub Actions. 

  On semver-compliant tag push, the GoReleaser GitHub Action will trigger a GoReleaser release. We can update the .goreleaser.yml config to target a non-default matrix of OS and architecture if necessary in the future.

* feat(docs): update README to state Kleat's readiness for use in dev clusters! 
