### PR TITLE
feat(release): add docs, windows release target, and fix ldflags for version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,3 @@
 builds:
 - ldflags:
-    - -s -w -X cmd.version={{.Version}} -X cmd.commit={{.Commit}} -X cmd.date={{.Date}}
+    - -s -w -X github.com/spinnaker/kleat/cmd.version={{.Version}} -X github.com/spinnaker/kleat/cmd.commit={{.Commit}} -X github.com/spinnaker/kleat/cmd.date={{.Date}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,10 @@
 builds:
 - ldflags:
     - -s -w -X github.com/spinnaker/kleat/cmd.version={{.Version}} -X github.com/spinnaker/kleat/cmd.commit={{.Commit}} -X github.com/spinnaker/kleat/cmd.date={{.Date}}
+  # By default, will build each specified $GOOS for the default $GOARCH options of 386 and amd64.
+  # If necessary in the future, can specify non-default $GOARCH options under `goarch` key per
+  # https://goreleaser.com/customization/build/.
+  goos:
+    - darwin
+    - linux
+    - windows

--- a/README.md
+++ b/README.md
@@ -91,3 +91,14 @@ be used as input to Kleat.
   acceptable to remove all values for which the microservice's deafult value is
   acceptable. For example, if you do not use the Google App Engine provider, you
   can remove the `Providers.AppengineProvider` block from your halconfig.
+
+### Installation
+
+Download the appropriate binary from the
+[releases page](https://github.com/spinnaker/kleat/releases/latest).
+
+### Usage
+
+- `kleat generate /path/to/halconfig /path/to/output/directory`
+- `kleat help`
+- `kleat version`


### PR DESCRIPTION
* feat(docs): add Installation and Usage sections to README 

* fix(release): qualify ldflags packages as full import paths 

  When ldflags are intended to be injected in non-main packages, the package name must be fully qualified.

* feat(release): include windows as $GOOS target 

  Kleat will now be released for the matrix of $GOOS (darwin, linux, windows) and $GOARCH (386, amd64), which are all valid combinations per https://golang.org/doc/install/source#environment. Added documentation to .goreleaser.yml in case users need additional combinations in the future.
