### PR TITLE
feat(stats): Pass version to echo config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 builds:
 - ldflags:
-    - -s -w -X github.com/spinnaker/kleat/cmd.version={{.Version}} -X github.com/spinnaker/kleat/cmd.commit={{.Commit}} -X github.com/spinnaker/kleat/cmd.date={{.Date}}
+    - -s -w -X github.com/spinnaker/kleat/pkg/version.Version={{.Version}} -X github.com/spinnaker/kleat/pkg/version.Commit={{.Commit}} -X github.com/spinnaker/kleat/pkg/version.Date={{.Date}}
   # By default, will build each specified $GOOS for the default $GOARCH options of 386 and amd64.
   # If necessary in the future, can specify non-default $GOARCH options under `goarch` key per
   # https://goreleaser.com/customization/build/.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,14 +18,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-)
-
-// Dynamically inserted at build time by goreleaser. See `ldflags` in
-// .goreleaser.yml.
-var (
-	version = "unknown"
-	commit  = "unknown"
-	date    = "unknown"
+	"github.com/spinnaker/kleat/pkg/version"
 )
 
 var versionCmd = &cobra.Command{
@@ -33,7 +26,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print kleat version",
 	Long:  "Print the version, commit, and release date of your kleat",
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Printf("Kleat has version %s built from %s on %s\n", version, commit, date)
+		cmd.Printf("Kleat has version %s built from %s on %s\n", version.Version, version.Commit, version.Date)
 	},
 }
 

--- a/internal/convert/echo.go
+++ b/internal/convert/echo.go
@@ -19,6 +19,7 @@ package convert
 import (
 	"github.com/spinnaker/kleat/api/client"
 	"github.com/spinnaker/kleat/api/client/config"
+	"github.com/spinnaker/kleat/pkg/version"
 )
 
 // HalToEcho generates the echo config for the supplied config.Hal h.
@@ -57,7 +58,5 @@ func getEchoStats(h *config.Hal) *config.Echo_Stats {
 }
 
 func getDeploymentMethod() *client.DeploymentMethod {
-	// TODO(ezimanyi): Make the version flag accessible outside the package so
-	// we can read it here.
-	return &client.DeploymentMethod{Type: "kleat", Version: "unknown"}
+	return &client.DeploymentMethod{Type: "kleat", Version: version.Version}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,10 @@
+// Package version holds constants that store information about the kleat build.
+package version
+
+// Dynamically inserted at build time by goreleaser. See `ldflags` in
+// .goreleaser.yml.
+var (
+	Version = "unknown"
+	Commit  = "unknown"
+	Date    = "unknown"
+)


### PR DESCRIPTION
* refactor(core): Make version fields accessible outside of package

  This commit pulls the variables to hold build-time information into their own package and exports them (so that consumers don't need to import things from cmd).

* feat(stats): Pass version to echo config

  Pass the version of kleat used to generate the config to the echo config so that it is recorded along with the deployment method.