### PR TITLE
fix(release): Fix changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
     if: startsWith(github.repository, 'spinnaker/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
Every kleat release was generating a full changelog of all commits ever made rather than only those since the last release.

The reason for this is that we were not fetching tags when cloning the repository, so when go-releaser used 'git describe' to find the last tag, it was not finding one and thus generating a changelog of all commits ever made.

This could be fixed by adding a --tags to the unshallow command, but it looks like the github action will fetch tags if you pass depth=0 to it (which means fetch all commits) so let's do that instead. It looks like in the two weeks since we added this config, go-releaser has updated their docs to now suggest adding depth=0 to the checkout command (whereas they previously had the unshallow command that was broken).