### PR TITLE
fix(protoc): Run protoc container as invoking user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ protobuilder:
 
 proto_command = docker run \
   --rm \
-  --mount type=bind,source=$(abspath api/proto/),target=/proto,readonly \
-  --mount type=bind,source=$(abspath api/client/),target=/output/go \
-  --mount type=bind,source=$(abspath docs),target=/output/doc \
+  --mount type=bind,source=$(abspath api/proto/),target=/mnt/proto,readonly \
+  --mount type=bind,source=$(abspath api/client/),target=/mnt/output/go \
+  --mount type=bind,source=$(abspath docs),target=/mnt/output/doc \
   kleat-protobuilder:latest
 
 proto: protobuilder

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 protobuilder:
 	docker build -q -t kleat-protobuilder:latest build/protoc/
 
-proto_command = docker run --rm -v $(abspath api/proto/):/proto -v $(abspath api/client):/output/go -v $(abspath docs):/output/doc kleat-protobuilder:latest
+proto_command = docker run \
+  --rm \
+  -v $(abspath api/proto/):/proto \
+  -v $(abspath api/client):/output/go \
+  -v $(abspath docs):/output/doc \
+  kleat-protobuilder:latest
 
 proto: protobuilder
 	$(proto_command) update

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ protobuilder:
 
 proto_command = docker run \
   --rm \
-  -v $(abspath api/proto/):/proto \
-  -v $(abspath api/client):/output/go \
-  -v $(abspath docs):/output/doc \
+  --mount type=bind,source=$(abspath api/proto/),target=/proto,readonly \
+  --mount type=bind,source=$(abspath api/client/),target=/output/go \
+  --mount type=bind,source=$(abspath docs),target=/output/doc \
   kleat-protobuilder:latest
 
 proto: protobuilder

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ protobuilder:
 
 proto_command = docker run \
   --rm \
+  --user $(shell id -u):$(shell id -g) \
   --mount type=bind,source=$(abspath api/proto/),target=/mnt/proto,readonly \
   --mount type=bind,source=$(abspath api/client/),target=/mnt/output/go \
   --mount type=bind,source=$(abspath docs),target=/mnt/output/doc \

--- a/build/protoc/Dockerfile
+++ b/build/protoc/Dockerfile
@@ -21,6 +21,5 @@ COPY --from=protoc /bin/protoc /usr/local/bin/protoc
 COPY --from=protoc /include/google /usr/local/include/google
 COPY --from=protoc-gen-go /protoc-gen-go /usr/local/bin/protoc-gen-go
 COPY --from=protoc-gen-doc /protoc-gen-doc /usr/local/bin/protoc-gen-doc
-RUN mkdir -p /output /staging/go /staging/doc
 COPY genproto.sh .
 ENTRYPOINT ["./genproto.sh"]

--- a/build/protoc/Dockerfile
+++ b/build/protoc/Dockerfile
@@ -34,4 +34,6 @@ COPY --chown=root:root --from=protoc-gen-go /home/curl/protoc-gen-go /usr/local/
 COPY --chown=root:root --from=protoc-gen-doc /home/curl/protoc-gen-doc /usr/local/bin/protoc-gen-doc
 COPY --chown=root:root genproto.sh /usr/local/bin/genproto.sh
 RUN chmod 755 /usr/local/bin/genproto.sh
+RUN adduser --disabled-password --gecos '' protoc
+USER protoc
 ENTRYPOINT ["/usr/local/bin/genproto.sh"]

--- a/build/protoc/Dockerfile
+++ b/build/protoc/Dockerfile
@@ -1,25 +1,37 @@
 FROM alpine:3.12.0 as curl
 RUN apk add --no-cache curl unzip
+RUN adduser --disabled-password --gecos '' curl
+USER curl
+WORKDIR /home/curl
 
 FROM curl as protoc-gen-go
 ARG PROTOC_GEN_GO_TAG=v1.25.0
 RUN curl -L https://github.com/protocolbuffers/protobuf-go/releases/download/$PROTOC_GEN_GO_TAG/protoc-gen-go.$PROTOC_GEN_GO_TAG.linux.amd64.tar.gz \
- | tar -xz
+ | tar -xz \
+ && chmod 755 protoc-gen-go
 
 FROM curl as protoc-gen-doc
 ARG PROTOC_GEN_DOC_TAG=1.3.2
 RUN curl -L https://github.com/pseudomuto/protoc-gen-doc/releases/download/v$PROTOC_GEN_DOC_TAG/protoc-gen-doc-$PROTOC_GEN_DOC_TAG.linux-amd64.go1.12.6.tar.gz \
- | tar --strip-components=1 -xz
+ | tar --strip-components=1 -xz \
+ && chmod 755 protoc-gen-doc
 
 FROM curl as protoc
 ARG PROTOC_VERSION=3.12.3
 RUN curl -vLo protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
- && unzip protoc.zip
+ && unzip protoc.zip \
+ # We want all files/folders in bin/ to be executable
+ && chmod -R 755 bin/ \
+ # Files under include/ should not be executable so we need
+ # to run a separate command for files/folders
+ && find include/ -type d -exec chmod 755 {} \+ \
+ && find include/ -type f -exec chmod 644 {} \+
 
 FROM debian:buster-slim
-COPY --from=protoc /bin/protoc /usr/local/bin/protoc
-COPY --from=protoc /include/google /usr/local/include/google
-COPY --from=protoc-gen-go /protoc-gen-go /usr/local/bin/protoc-gen-go
-COPY --from=protoc-gen-doc /protoc-gen-doc /usr/local/bin/protoc-gen-doc
-COPY genproto.sh .
-ENTRYPOINT ["./genproto.sh"]
+COPY --chown=root:root --from=protoc /home/curl/bin/protoc /usr/local/bin/protoc
+COPY --chown=root:root --from=protoc /home/curl/include/google /usr/local/include/google
+COPY --chown=root:root --from=protoc-gen-go /home/curl/protoc-gen-go /usr/local/bin/protoc-gen-go
+COPY --chown=root:root --from=protoc-gen-doc /home/curl/protoc-gen-doc /usr/local/bin/protoc-gen-doc
+COPY --chown=root:root genproto.sh /usr/local/bin/genproto.sh
+RUN chmod 755 /usr/local/bin/genproto.sh
+ENTRYPOINT ["/usr/local/bin/genproto.sh"]

--- a/build/protoc/genproto.sh
+++ b/build/protoc/genproto.sh
@@ -4,25 +4,25 @@ set -e
 PROTOC_FLAGS=""
 
 gen_proto() {
-  output_dir=$1
-  find /proto -name *.proto | sort | xargs protoc \
+  mkdir -p /tmp/staging/go /tmp/staging/doc
+  find /mnt/proto -name *.proto | sort | xargs protoc \
     $PROTOC_FLAGS \
-    --proto_path=/proto \
-    --go_out=paths=source_relative:$1/go \
-    --doc_out=$1/doc \
+    --proto_path=/mnt/proto \
+    --go_out=paths=source_relative:/tmp/staging/go \
+    --doc_out=/tmp/staging/doc \
     --doc_opt=markdown,docs.md
 }
 
 update_proto() {
-  gen_proto /staging
-  rm -rf /output/go/* /output/doc/*
-  cp -r /staging/doc/* /output/doc/
-  cp -r /staging/go/* /output/go/
+  gen_proto
+  rm -rf /mnt/output/go/* /mnt/output/doc/*
+  cp -r /tmp/staging/doc/* /mnt/output/doc/
+  cp -r /tmp/staging/go/* /mnt/output/go/
 }
 
 check_proto() {
-  gen_proto /staging
-  if ! diff -r /staging /output; then
+  gen_proto
+  if ! diff -r /tmp/staging /mnt/output; then
     echo "Protocol buffer compilation out of date. Please run 'make proto' and commit the changes."
     echo "To help with debugging, the difference between the committed and generated code is printed above."
     exit 1


### PR DESCRIPTION
* style(proto): Add newlines in docker command 

  This will make it easier to see what changed when adding/removing arguments to the command.

* refactor(proto): Use mount instead of volume command 

  The mount command is newer and recommended by Docker. It also allows us to mount a volume readonly, which we want to do for the proto directory (which is input only).

* refactor(protoc): Use better directories in container 

  It's customary for mounted filesystems to be in /mnt; let's mount our files there instead of directly in the root of the filesystem.

  Rather than have a top-level staging directory, make this directory in /tmp. Also create it as part of the genproto script so it's automatically owned by whichever user is running the script.

* fix(protoc): Fix file permissions in kleat-protobuilder 

  This commit updates the intermediate containers used to fetch protoc and its dependencies to no longer run as root.

  The first change is to update the 'curl' container to run as a non-root user 'curl' to set the work directory to this user's home directory.

  After downloading and unzipping the desired files, we run chmod to set the desired permissions, which in many cases are not set to what we want in the tar/zip archive. We want 755 for directories and executable files and 644 for non-executable files, so that only the owner can modify but anyone can use the files when running protoc.

  When copying the files to the kleat-protobuilder container, explicitly have them owned by root (leaving the permissions as what we set them to after downloading). This matches the way things are normally installed on linux, where root owns the files and is the only user with permission to write, but any user can read/execute the files.

  In the case of genproto, we'll explicitly follow up with a chmod to ensure it has mode 755 as we can't necessarily control what the user has on their system.

  As of this commit, we've fixed the permissions so that it is now possible to run the kleat-protobuilder as a non-root user by passing the -u flag to docker, but we're not actually doing that yet, which will follow in an upcoming commit.

* fix(protoc): Run protoc container as invoking user 

  This commit adds the -u flag to the docker command running the protocol buffer compilation, so that the container runs with the same uid/gid as the invoking user. This will cause any output files to have this uid/gid (instead of being owned by root as before).

  I've also created a user 'protoc' in the container and set the user to that user. This is really just a fallback so we're falling back to a non-root user; this will always be overridden by the --user flag that we've added to the docker run command.
