### PR TITLE
fix(core): remove dups 'reading' on fileio package top level synopsis

### DIFF
--- a/internal/fileio/fileio.go
+++ b/internal/fileio/fileio.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Package fileio supports reading reading and writing config files to the
+// Package fileio supports reading and writing config files to the
 // filesystem.
 package fileio
 


### PR DESCRIPTION
Remove dups 'reading' on fileio package top-level synopsis.