### PR TITLE
feat(dependencies): Add dependabot config

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/build/protoc"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Let's use dependabot to keep our go dependencies up to date, as well as the base images in our Dockerfile for compiling protos.

This will *not* upgrade the versions of the following in our build
container, which we'll still need to do manually:
* protoc
* protoc-gen-go
* protoc-gen-doc

But it still seems worthwhile to have some of these dependencies auto-bumped for us.