### PR TITLE
docs(kleat): Link to instructions in kustomization-base repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ It is currently under active development, but is ready for early adopters to try
 in development clusters! Please share any feedback in the #kleat channel in
 [Spinnaker slack](join.spinnaker.io).
 
+Please see
+[spinnaker/kustomization-base](https://github.com/spinnaker/kustomization-base)
+for step-by-step instructions on how to install Spinnaker to a Kubernetes
+cluster using `kleat` and `kustomize`.
+
 ### Migrating from Halyard
 
 Please see the [migration README](/migration/README.md) for details on migrating


### PR DESCRIPTION
Users landing on the kleat repo often have trouble finding the detailed install instructions we put in the kustomization-base repo. Let's link to them from the kleat README.

Maybe at some point these instructions should live in the kleat repo as most users looking up the tool will land here, but at least for now the link should help.