### PR TITLE
chore(deps): Upgrade to go 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Ensure packages and dependencies compile
         run: go build ./...
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Create release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spinnaker/kleat
 
-go 1.14
+go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2


### PR DESCRIPTION
Go 1.15 was released about a month ago and is now on 1.15.2; let's upgrade kleat to use it.