### PR TITLE
chore(deps): Upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Ensure code formatting and style is consistent
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v1.32


### PR DESCRIPTION
Upgraded [golangci-lint](https://github.com/golangci/golangci-lint) version from `v1.31` to `v1.32`.

The release notes of `v1.32.x`:

- https://github.com/golangci/golangci-lint/releases/tag/v1.32.0
- https://github.com/golangci/golangci-lint/releases/tag/v1.32.1
- https://github.com/golangci/golangci-lint/releases/tag/v1.32.2
